### PR TITLE
Add deprecation tracking and silenced deprecation detection

### DIFF
--- a/dual-boot/SKILL.md
+++ b/dual-boot/SKILL.md
@@ -168,7 +168,7 @@ See `workflows/cleanup-workflow.md` for the complete post-upgrade cleanup proces
 3. **Always use `NextRails.next?` for version-dependent code** — never `respond_to?`
 4. **Test both versions** — run `bundle exec rspec` and `BUNDLE_GEMFILE=Gemfile.next bundle exec rspec`
 5. **Clean up after upgrade** — search for and remove all `NextRails.next?` branches
-6. **Add `next_rails` to all environments** — not just development
+6. **Add `next_rails` at the Gemfile root level** — not inside a `:development` or `:test` group
 
 ---
 

--- a/dual-boot/SKILL.md
+++ b/dual-boot/SKILL.md
@@ -102,6 +102,7 @@ Claude should activate this skill when user says:
 See `workflows/setup-workflow.md` for the complete step-by-step process.
 
 **Summary:**
+0. Verify deprecation warnings are not silenced (see `reference/deprecation-tracking.md`)
 1. Check if dual-boot is already set up (look for `Gemfile.next`)
 2. Add `next_rails` gem to Gemfile
 3. Run `bundle install`
@@ -146,6 +147,7 @@ See `workflows/cleanup-workflow.md` for the complete post-upgrade cleanup proces
 - `SKILL.md` - This file (entry point)
 
 ### Reference Materials
+- `reference/deprecation-tracking.md` - Detecting silenced deprecations and configuring tracking (Rails 3.0+)
 - `reference/code-patterns.md` - `NextRails.next?` usage examples in application code
 - `reference/ci-configuration.md` - CI setup for dual-boot (GitHub Actions, CircleCI, Jenkins)
 - `reference/gemfile-examples.md` - Gemfile configuration patterns for dual-boot
@@ -161,11 +163,12 @@ See `workflows/cleanup-workflow.md` for the complete post-upgrade cleanup proces
 
 ## Key Principles
 
-1. **Never run `next_rails --init` if `Gemfile.next` exists** — it will duplicate the `next?` method
-2. **Always use `NextRails.next?` for version-dependent code** — never `respond_to?`
-3. **Test both versions** — run `bundle exec rspec` and `BUNDLE_GEMFILE=Gemfile.next bundle exec rspec`
-4. **Clean up after upgrade** — search for and remove all `NextRails.next?` branches
-5. **Add `next_rails` to all environments** — not just development
+1. **Ensure deprecation warnings are visible** — silenced deprecations mean you can't track upgrade progress
+2. **Never run `next_rails --init` if `Gemfile.next` exists** — it will duplicate the `next?` method
+3. **Always use `NextRails.next?` for version-dependent code** — never `respond_to?`
+4. **Test both versions** — run `bundle exec rspec` and `BUNDLE_GEMFILE=Gemfile.next bundle exec rspec`
+5. **Clean up after upgrade** — search for and remove all `NextRails.next?` branches
+6. **Add `next_rails` to all environments** — not just development
 
 ---
 

--- a/dual-boot/reference/deprecation-tracking.md
+++ b/dual-boot/reference/deprecation-tracking.md
@@ -42,40 +42,126 @@ ActiveSupport::Deprecation.silence { ... }
 
 ### Detection Commands
 
+Search from the project root to catch configuration in any directory structure (standard Rails, Packwerk packs, engines, etc.):
+
 ```bash
 # Find all deprecation configuration
-grep -rn "active_support.deprecation" config/
-grep -rn "report_deprecations" config/
-grep -rn "Deprecation.silenced" app/ lib/ config/
-grep -rn "Deprecation.silence" app/ lib/ config/
+grep -rn "active_support.deprecation" .
+grep -rn "report_deprecations" .
+grep -rn "Deprecation.silenced" .
+grep -rn "Deprecation.silence" .
 ```
 
 If any of these are silencing deprecations, fix them before proceeding with the upgrade.
 
 ---
 
-## Step 2: Configure Deprecation Behavior
+## Step 2: Save Deprecation Inventory with DeprecationTracker
 
-### Recommended Settings
+The `next_rails` gem includes `DeprecationTracker` which captures all deprecation warnings during test runs and saves them to a file. This gives you a complete inventory without stopping on the first failure (unlike `:raise`).
+
+### Setup
+
+Ensure `next_rails` is in your Gemfile at the **root level** (not inside a `group` block):
 
 ```ruby
-# config/environments/development.rb
-config.active_support.deprecation = :raise
-
-# config/environments/test.rb
-config.active_support.deprecation = :raise
-
-# config/environments/production.rb
-config.active_support.deprecation = :notify
+# Gemfile
+# MUST be at root level — not in :development or :test group
+gem 'next_rails'
 ```
 
-Setting `:raise` in test/development means you'll see deprecations immediately as failures. This is the ideal end state, but if your app has many existing deprecations, you may need a gradual approach — see "Custom Deprecation Behavior" below.
+Then configure RSpec:
+
+```ruby
+# spec/spec_helper.rb (or spec/rails_helper.rb)
+RSpec.configure do |config|
+  DeprecationTracker.track_rspec(
+    config,
+    shitlist_path: "spec/support/deprecation_warning.shitlist.json",
+    mode: ENV.fetch("DEPRECATION_TRACKER", "save"),
+    transform_message: -> (message) { message.gsub("#{Rails.root}/", "") }
+  )
+end
+```
+
+- **`shitlist_path`** — where to save/read the deprecation inventory (required, no default)
+- **`mode`** — defaults to `save` so it always tracks
+- **`transform_message`** — strips the Rails root path from messages so the shitlist is portable across environments
+
+### Save the Deprecation Shitlist
+
+Run the test suite with `DEPRECATION_TRACKER=save` to collect all deprecation warnings:
+
+```bash
+DEPRECATION_TRACKER=save bundle exec rspec
+```
+
+This generates `spec/support/deprecation_warning.shitlist.json` — a JSON file listing every unique deprecation warning found during the run.
+
+> **Note:** The shitlist path is hardcoded to `spec/support/deprecation_warning.shitlist.json`. Make sure this directory exists.
+
+### Prevent Regressions
+
+Once you have a shitlist, run with `DEPRECATION_TRACKER=save` after fixing deprecations to update the file. As you fix deprecations, the shitlist shrinks. Any new deprecation not in the shitlist will cause a failure, preventing regressions.
+
+### Workflow
+
+1. `DEPRECATION_TRACKER=save bundle exec rspec` — generates initial shitlist
+2. Review the shitlist to understand the scope of deprecations
+3. Fix one category of deprecation (e.g., `update_attributes`)
+4. `DEPRECATION_TRACKER=save bundle exec rspec` — updates the shitlist (it should shrink)
+5. Repeat until the shitlist is empty
+6. Commit the shitlist file so the team tracks progress together
+
+### CI with Parallel Test Execution
+
+`DeprecationTracker` does not natively support parallel execution. When CI splits tests across multiple nodes/containers (e.g., CircleCI parallelism, parallel_tests gem), each node only sees its subset of deprecations. You need to collect and merge the results.
+
+**Strategy: Save per-node, merge after**
+
+1. On each CI node, run with `DEPRECATION_TRACKER=save` as normal
+2. Each node produces its own `spec/support/deprecation_warning.shitlist.json`
+3. After all nodes finish, collect and merge the shitlist files:
+
+```bash
+# Example merge script (run after all parallel nodes complete)
+# Collects shitlist JSON files from each node and merges them
+
+require 'json'
+
+shitlists = Dir.glob("node-*/spec/support/deprecation_warning.shitlist.json")
+merged = {}
+
+shitlists.each do |file|
+  data = JSON.parse(File.read(file))
+  data.each do |key, values|
+    merged[key] ||= []
+    merged[key] = (merged[key] + values).uniq
+  end
+end
+
+File.write("spec/support/deprecation_warning.shitlist.json", JSON.pretty_generate(merged))
+```
+
+The exact collection mechanism depends on your CI setup:
+- **CircleCI**: Use `persist_to_workspace` / `attach_workspace` to gather shitlists from parallel containers
+- **GitHub Actions**: Use `upload-artifact` / `download-artifact` across matrix jobs
+- **parallel_tests gem**: Each process writes to the same filesystem, so you can glob the results directly
+
+> **Tip:** Run the initial `DEPRECATION_TRACKER=save` locally (non-parallel) to generate the first complete shitlist. Use the parallel merge strategy in CI for ongoing regression checks.
+
+### Limitations
+
+- **Not compatible with `minitest/parallel_fork`** — use standard minitest or RSpec
+- **Shitlist path is hardcoded** — must be `spec/support/deprecation_warning.shitlist.json`
+- **No native parallel support** — requires manual merge when using CI parallelism (see above)
+- **RSpec only** for the `track_rspec` helper — Minitest requires manual integration
 
 ---
 
-## Step 3: Custom Deprecation Behavior (Gradual Approach)
+## Step 3: Custom Deprecation Behavior (Alternative Approach)
 
-If setting `:raise` produces too many failures at once, use a custom behavior to selectively raise on deprecations you've already fixed, while logging the rest. This prevents regressions on fixed deprecations while giving you time to address the remaining ones.
+If `DeprecationTracker` doesn't fit your setup (e.g., Minitest with parallel_fork, or you want more control), you can use custom deprecation behaviors to selectively raise on fixed deprecations while logging the rest.
 
 Based on [FastRuby.io's custom deprecation behavior approach](https://www.fastruby.io/blog/custom-deprecation-behavior.html):
 
@@ -99,9 +185,6 @@ config.active_support.deprecation = :log
 ### Rails 5.2+ (Backported via Custom Lambda)
 
 ```ruby
-# config/environments/test.rb
-config.active_support.deprecation = :stderr
-
 # config/initializers/custom_deprecation_behavior.rb
 ActiveSupport::Deprecation.behavior = ->(message, callstack, deprecation_horizon, gem_name) {
   # Deprecations you've already fixed — raise if they reappear
@@ -164,24 +247,15 @@ ActiveSupport::Deprecation.behavior = ->(message, callstack) {
 }
 ```
 
-### Workflow for Custom Behavior
-
-1. Start with an empty `disallowed` list and `:stderr` or `:log` as the default
-2. Run tests — collect all deprecation warnings
-3. Fix one category of deprecation (e.g., `update_attributes`)
-4. Add it to the `disallowed` list
-5. Repeat until all deprecations are fixed
-6. Switch to `config.active_support.deprecation = :raise` when the list covers everything
-
 ---
 
 ## Step 4: Maintenance
 
 After completing the upgrade:
 
-- Review the disallowed list and remove entries for deprecations that no longer exist in the new Rails version
-- This avoids unnecessary string comparisons on every deprecation check
-- If you've fixed all deprecations, switch to `:raise` and remove the custom behavior entirely
+- If using DeprecationTracker: delete the shitlist file once it's empty
+- If using custom behaviors: remove entries for deprecations that no longer exist in the new Rails version
+- If you've fixed all deprecations, you can switch to `config.active_support.deprecation = :raise` for strict mode going forward
 
 ---
 
@@ -189,7 +263,8 @@ After completing the upgrade:
 
 | What to check | Command |
 |---|---|
-| Silenced deprecations | `grep -rn "deprecation.*silence\|silenced.*true\|report_deprecations.*false" config/` |
-| Current behavior | `grep -rn "active_support.deprecation" config/environments/` |
-| Custom behaviors | `grep -rn "Deprecation.behavior" config/ app/ lib/` |
+| Silenced deprecations | `grep -rn "deprecation.*silence\|silenced.*true\|report_deprecations.*false" .` |
+| Current behavior | `grep -rn "active_support.deprecation" .` |
+| Custom behaviors | `grep -rn "Deprecation.behavior" .` |
+| Save deprecation inventory | `DEPRECATION_TRACKER=save bundle exec rspec` |
 | Existing warnings | `bundle exec rspec 2>&1 \| grep "DEPRECATION WARNING"` |

--- a/dual-boot/reference/deprecation-tracking.md
+++ b/dual-boot/reference/deprecation-tracking.md
@@ -1,0 +1,195 @@
+# Deprecation Tracking with Dual-Boot
+
+**Ensuring deprecation warnings are visible and tracked during upgrades**
+
+---
+
+## Why This Matters
+
+Deprecation warnings are your roadmap during a Rails upgrade — they tell you exactly what will break in the next version. If deprecations are silenced, you're flying blind. Before setting up dual-boot, you must ensure deprecation warnings are visible and tracked.
+
+---
+
+## Step 1: Detect If Deprecations Are Silenced
+
+Check these files for silenced deprecations:
+
+### Check `config/environments/test.rb`
+
+```ruby
+# BAD — deprecations are invisible
+config.active_support.deprecation = :silence
+
+# BAD — all deprecation behaviors disabled (Rails 7.0+)
+config.active_support.report_deprecations = false
+```
+
+### Check `config/environments/development.rb`
+
+Same patterns as above — `:silence` or `report_deprecations = false`.
+
+### Check for Global Silencing
+
+Search for these patterns anywhere in the codebase:
+
+```ruby
+# Silences all deprecation warnings globally
+ActiveSupport::Deprecation.silenced = true
+
+# Silences within a block (may be acceptable in narrow cases)
+ActiveSupport::Deprecation.silence { ... }
+```
+
+### Detection Commands
+
+```bash
+# Find all deprecation configuration
+grep -rn "active_support.deprecation" config/
+grep -rn "report_deprecations" config/
+grep -rn "Deprecation.silenced" app/ lib/ config/
+grep -rn "Deprecation.silence" app/ lib/ config/
+```
+
+If any of these are silencing deprecations, fix them before proceeding with the upgrade.
+
+---
+
+## Step 2: Configure Deprecation Behavior
+
+### Recommended Settings
+
+```ruby
+# config/environments/development.rb
+config.active_support.deprecation = :raise
+
+# config/environments/test.rb
+config.active_support.deprecation = :raise
+
+# config/environments/production.rb
+config.active_support.deprecation = :notify
+```
+
+Setting `:raise` in test/development means you'll see deprecations immediately as failures. This is the ideal end state, but if your app has many existing deprecations, you may need a gradual approach — see "Custom Deprecation Behavior" below.
+
+---
+
+## Step 3: Custom Deprecation Behavior (Gradual Approach)
+
+If setting `:raise` produces too many failures at once, use a custom behavior to selectively raise on deprecations you've already fixed, while logging the rest. This prevents regressions on fixed deprecations while giving you time to address the remaining ones.
+
+Based on [FastRuby.io's custom deprecation behavior approach](https://www.fastruby.io/blog/custom-deprecation-behavior.html):
+
+### Rails 6.1+ (Built-in Support)
+
+```ruby
+# config/environments/test.rb
+
+# Raise on specific deprecations you've already fixed (prevents regressions)
+config.active_support.disallowed_deprecation = :raise
+config.active_support.disallowed_deprecation_warnings = [
+  /update_attributes/,          # Already migrated to .update
+  /Merging .* no longer/,       # Already fixed merge conditions
+  "before_filter",              # Already migrated to before_action
+]
+
+# Log everything else (so you can see remaining work)
+config.active_support.deprecation = :log
+```
+
+### Rails 5.2+ (Backported via Custom Lambda)
+
+```ruby
+# config/environments/test.rb
+config.active_support.deprecation = :stderr
+
+# config/initializers/custom_deprecation_behavior.rb
+ActiveSupport::Deprecation.behavior = ->(message, callstack, deprecation_horizon, gem_name) {
+  # Deprecations you've already fixed — raise if they reappear
+  disallowed = [
+    "update_attributes",
+    /before_filter/,
+  ]
+
+  if disallowed.any? { |pattern|
+    pattern.is_a?(Regexp) ? pattern === message : message.include?(pattern)
+  }
+    ActiveSupport::Deprecation::DEFAULT_BEHAVIORS[:raise].call(
+      message, callstack, deprecation_horizon, gem_name
+    )
+  else
+    ActiveSupport::Deprecation::DEFAULT_BEHAVIORS[:stderr].call(
+      message, callstack, deprecation_horizon, gem_name
+    )
+  end
+}
+```
+
+### Rails 4.0–5.1 (2-Argument Signature)
+
+```ruby
+# config/initializers/custom_deprecation_behavior.rb
+ActiveSupport::Deprecation.behavior = ->(message, callstack) {
+  disallowed = [
+    "update_attributes",
+    /before_filter/,
+  ]
+
+  if disallowed.any? { |pattern|
+    pattern.is_a?(Regexp) ? pattern === message : message.include?(pattern)
+  }
+    ActiveSupport::Deprecation::DEFAULT_BEHAVIORS[:raise].call(message, callstack)
+  else
+    ActiveSupport::Deprecation::DEFAULT_BEHAVIORS[:stderr].call(message, callstack)
+  end
+}
+```
+
+### Rails 3.0–3.2 (No `:raise` Behavior)
+
+```ruby
+# config/initializers/custom_deprecation_behavior.rb
+ActiveSupport::Deprecation.behavior = ->(message, callstack) {
+  disallowed = [
+    "update_attributes",
+    /before_filter/,
+  ]
+
+  if disallowed.any? { |pattern|
+    pattern.is_a?(Regexp) ? pattern === message : message.include?(pattern)
+  }
+    raise message
+  end
+
+  ActiveSupport::Deprecation::DEFAULT_BEHAVIORS[:stderr].call(message, callstack)
+}
+```
+
+### Workflow for Custom Behavior
+
+1. Start with an empty `disallowed` list and `:stderr` or `:log` as the default
+2. Run tests — collect all deprecation warnings
+3. Fix one category of deprecation (e.g., `update_attributes`)
+4. Add it to the `disallowed` list
+5. Repeat until all deprecations are fixed
+6. Switch to `config.active_support.deprecation = :raise` when the list covers everything
+
+---
+
+## Step 4: Maintenance
+
+After completing the upgrade:
+
+- Review the disallowed list and remove entries for deprecations that no longer exist in the new Rails version
+- This avoids unnecessary string comparisons on every deprecation check
+- If you've fixed all deprecations, switch to `:raise` and remove the custom behavior entirely
+
+---
+
+## Quick Reference
+
+| What to check | Command |
+|---|---|
+| Silenced deprecations | `grep -rn "deprecation.*silence\|silenced.*true\|report_deprecations.*false" config/` |
+| Current behavior | `grep -rn "active_support.deprecation" config/environments/` |
+| Custom behaviors | `grep -rn "Deprecation.behavior" config/ app/ lib/` |
+| Existing warnings | `bundle exec rspec 2>&1 \| grep "DEPRECATION WARNING"` |

--- a/dual-boot/workflows/setup-workflow.md
+++ b/dual-boot/workflows/setup-workflow.md
@@ -170,7 +170,38 @@ BUNDLE_GEMFILE=Gemfile.next bundle exec rspec
 
 ---
 
-## Step 7: Commit Dual-Boot Setup
+## Step 7: Set Up Deprecation Tracking with DeprecationTracker
+
+The `next_rails` gem includes `DeprecationTracker`, which captures all deprecation warnings during test runs and saves them to a JSON file. Set it up now so you have a complete deprecation inventory from the start.
+
+### Configure RSpec
+
+Add the following to `spec/spec_helper.rb` (or `spec/rails_helper.rb`):
+
+```ruby
+RSpec.configure do |config|
+  DeprecationTracker.track_rspec(
+    config,
+    shitlist_path: "spec/support/deprecation_warning.shitlist.json",
+    mode: ENV.fetch("DEPRECATION_TRACKER", "save"),
+    transform_message: -> (message) { message.gsub("#{Rails.root}/", "") }
+  )
+end
+```
+
+### Generate the Initial Deprecation Inventory
+
+```bash
+DEPRECATION_TRACKER=save bundle exec rspec
+```
+
+This creates `spec/support/deprecation_warning.shitlist.json` — a JSON file listing every unique deprecation warning found during the run. Review it to understand the scope of deprecations you need to address.
+
+See `reference/deprecation-tracking.md` for the full workflow (updating the shitlist, preventing regressions, CI with parallel execution, and alternative approaches).
+
+---
+
+## Step 8: Commit Dual-Boot Setup
 
 ```bash
 git add Gemfile Gemfile.next Gemfile.next.lock

--- a/dual-boot/workflows/setup-workflow.md
+++ b/dual-boot/workflows/setup-workflow.md
@@ -7,6 +7,26 @@
 
 ---
 
+## Step 0: Verify Deprecation Warnings Are Not Silenced
+
+Before setting up dual-boot, ensure deprecation warnings are visible. Silenced deprecations mean you can't track upgrade progress.
+
+**Check for silenced deprecations:**
+
+```bash
+grep -rn "deprecation.*silence\|silenced.*true\|report_deprecations.*false" config/
+```
+
+**If deprecations are silenced:**
+1. Change `:silence` to `:stderr` or `:log` (or `:raise` if you want strict mode)
+2. Remove `ActiveSupport::Deprecation.silenced = true` if found
+3. Remove `config.active_support.report_deprecations = false` if found (Rails 7.0+)
+4. Run the test suite to see current deprecation warnings
+
+See `reference/deprecation-tracking.md` for detailed configuration guidance, including a gradual approach using custom deprecation behaviors for apps with many existing warnings.
+
+---
+
 ## Step 1: Check if Dual-Boot is Already Set Up
 
 ```bash


### PR DESCRIPTION
## Summary

- Adds **Step 0: Verify Deprecation Warnings Are Not Silenced** to the dual-boot setup workflow
- Adds new `reference/deprecation-tracking.md` with comprehensive guidance on detecting silenced deprecations and configuring custom deprecation behavior across Rails versions (3.0 through 8.x)
- Updates SKILL.md with new reference, key principle, and workflow summary

## Why

Deprecation warnings are the roadmap during a Rails upgrade — they tell you exactly what will break in the next version. If deprecations are silenced (`:silence`, `silenced = true`, `report_deprecations = false`), you're flying blind during the upgrade.

The dual-boot skill owns the `next_rails` gem relationship, and deprecation visibility is a prerequisite for effective dual-boot testing. This check should happen before setting up dual-boot, not after.

Custom deprecation behavior (based on [FastRuby.io's approach](https://www.fastruby.io/blog/custom-deprecation-behavior.html)) provides a gradual path for apps with many existing deprecations — selectively raise on fixed deprecations while logging the rest, with patterns for Rails 3.0 through 8.x.

## Changes

- `dual-boot/reference/deprecation-tracking.md` (new) — Detection commands, recommended settings, custom behavior examples for Rails 3.0-3.2, 4.0-5.1, 5.2+, and 6.1+
- `dual-boot/workflows/setup-workflow.md` — Added Step 0 deprecation check before dual-boot setup
- `dual-boot/SKILL.md` — Added reference listing, key principle, and workflow summary update

## Test plan

- [ ] Verify skill detects `:silence` in config/environments
- [ ] Verify skill detects `ActiveSupport::Deprecation.silenced = true`
- [ ] Verify skill detects `report_deprecations = false` (Rails 7.0+)
- [ ] Verify custom behavior examples are syntactically correct for each Rails version range