### PR TITLE
Fix cleanup to preserve Gemfile.next.lock versions

### DIFF
--- a/dual-boot/SKILL.md
+++ b/dual-boot/SKILL.md
@@ -134,9 +134,9 @@ See `workflows/cleanup-workflow.md` for the complete post-upgrade cleanup proces
 2. Keep only the `NextRails.next?` (true) branch code
 3. Remove all `else` branches
 4. Remove `next?` method from Gemfile
-5. Remove `Gemfile.next` and `Gemfile.next.lock`
-6. Remove the `next_rails` gem if no longer needed
-7. Run `bundle install` and full test suite
+5. Remove `next_rails` gem if no longer needed
+6. Remove `Gemfile.next` and replace `Gemfile.lock` with `Gemfile.next.lock`
+7. Run full test suite
 
 ---
 

--- a/dual-boot/SKILL.md
+++ b/dual-boot/SKILL.md
@@ -136,7 +136,9 @@ See `workflows/cleanup-workflow.md` for the complete post-upgrade cleanup proces
 4. Remove `next?` method from Gemfile
 5. Remove `next_rails` gem if no longer needed
 6. Remove `Gemfile.next` and replace `Gemfile.lock` with `Gemfile.next.lock`
-7. Run full test suite
+7. Update CI to remove dual-boot configuration
+8. Run full test suite
+9. Commit cleanup changes
 
 ---
 

--- a/dual-boot/workflows/cleanup-workflow.md
+++ b/dual-boot/workflows/cleanup-workflow.md
@@ -86,7 +86,7 @@ gem 'next_rails'
 
 ## Step 5: Remove Dual-Boot Files and Preserve Lock Versions
 
-Replace `Gemfile.lock` with `Gemfile.next.lock` to keep the exact gem versions that were tested during the upgrade — running `bundle install` from scratch could resolve to different versions.
+Replace `Gemfile.lock` with `Gemfile.next.lock` to keep the exact gem versions that were tested during the upgrade, and remove `Gemfile.next` which is no longer needed — running `bundle install` from scratch could resolve to different versions.
 
 ```bash
 rm Gemfile.next Gemfile.lock

--- a/dual-boot/workflows/cleanup-workflow.md
+++ b/dual-boot/workflows/cleanup-workflow.md
@@ -84,23 +84,18 @@ gem 'next_rails'
 
 ---
 
-## Step 5: Remove Dual-Boot Files
+## Step 5: Remove Dual-Boot Files and Preserve Lock Versions
+
+Replace `Gemfile.lock` with `Gemfile.next.lock` to keep the exact gem versions that were tested during the upgrade — running `bundle install` from scratch could resolve to different versions.
 
 ```bash
-rm Gemfile.next Gemfile.next.lock
+rm Gemfile.next
+mv Gemfile.next.lock Gemfile.lock
 ```
 
 ---
 
-## Step 6: Reinstall Dependencies
-
-```bash
-bundle install
-```
-
----
-
-## Step 7: Run Full Test Suite
+## Step 6: Run Full Test Suite
 
 ```bash
 bundle exec rspec
@@ -110,13 +105,13 @@ Ensure all tests pass without dual-boot.
 
 ---
 
-## Step 8: Update CI Configuration
+## Step 7: Update CI Configuration
 
 Remove the dual-boot CI job/matrix entry that ran tests with `BUNDLE_GEMFILE=Gemfile.next`.
 
 ---
 
-## Step 9: Commit Cleanup
+## Step 8: Commit Cleanup
 
 ```bash
 git add -A

--- a/dual-boot/workflows/cleanup-workflow.md
+++ b/dual-boot/workflows/cleanup-workflow.md
@@ -89,7 +89,7 @@ gem 'next_rails'
 Replace `Gemfile.lock` with `Gemfile.next.lock` to keep the exact gem versions that were tested during the upgrade — running `bundle install` from scratch could resolve to different versions.
 
 ```bash
-rm Gemfile.next
+rm Gemfile.next Gemfile.lock
 mv Gemfile.next.lock Gemfile.lock
 ```
 


### PR DESCRIPTION
## Summary

- Replaces `rm Gemfile.next Gemfile.next.lock` + `bundle install` with `rm Gemfile.next` + `mv Gemfile.next.lock Gemfile.lock`
- Keeps the exact gem versions tested during the upgrade instead of letting Bundler resolve potentially different versions
- Updates SKILL.md cleanup summary to match

Closes #3

## Test plan

- [ ] Verify cleanup workflow steps are correctly numbered (Steps 1–8)
- [ ] Verify SKILL.md cleanup summary matches the workflow
- [ ] Verify the `mv` approach preserves lock versions in a real dual-boot cleanup

🤖 Generated with [Claude Code](https://claude.ai/claude-code)