### PR TITLE
Copy Gemfile.lock before installing next dependencies

### DIFF
--- a/dual-boot/SKILL.md
+++ b/dual-boot/SKILL.md
@@ -107,7 +107,10 @@ See `workflows/setup-workflow.md` for the complete step-by-step process.
 3. Run `bundle install`
 4. Run `next_rails --init` (only if `Gemfile.next` does NOT exist)
 5. Configure Gemfile with `next?` conditionals for the dependency being upgraded
-6. Run `bundle install`, copy `Gemfile.lock` as `Gemfile.next.lock`, then run `BUNDLE_GEMFILE=Gemfile.next bundle install`
+  6. Install dependencies for both versions:
+     - Current: `bundle install`
+     - Next: `cp Gemfile.lock Gemfile.next.lock && BUNDLE_GEMFILE=Gemfile.next bundle install`
+
 7. Verify both versions work
 
 ### Workflow 2: Add Version-Dependent Code

--- a/dual-boot/SKILL.md
+++ b/dual-boot/SKILL.md
@@ -107,7 +107,7 @@ See `workflows/setup-workflow.md` for the complete step-by-step process.
 3. Run `bundle install`
 4. Run `next_rails --init` (only if `Gemfile.next` does NOT exist)
 5. Configure Gemfile with `next?` conditionals for the dependency being upgraded
-6. Run `bundle install` and `next bundle install`
+6. Run `bundle install`, copy `Gemfile.lock` as `Gemfile.next.lock`, then run `BUNDLE_GEMFILE=Gemfile.next bundle install`
 7. Verify both versions work
 
 ### Workflow 2: Add Version-Dependent Code

--- a/dual-boot/workflows/setup-workflow.md
+++ b/dual-boot/workflows/setup-workflow.md
@@ -126,8 +126,9 @@ See `reference/gemfile-examples.md` for more patterns.
 # Install current version dependencies
 bundle install
 
-# Copy the current lock file so the next bundle starts from the same resolved versions
-# This avoids unwanted dependency upgrades
+# IMPORTANT: Copy Gemfile.lock BEFORE running the next bundle install.
+# Without this, bundler would resolve all dependencies from scratch and may
+# upgrade unrelated gems. By copying first, only gems in `if next?` blocks will change.
 cp Gemfile.lock Gemfile.next.lock
 
 # Install next version dependencies

--- a/dual-boot/workflows/setup-workflow.md
+++ b/dual-boot/workflows/setup-workflow.md
@@ -126,13 +126,11 @@ See `reference/gemfile-examples.md` for more patterns.
 # Install current version dependencies
 bundle install
 
+# Copy the current lock file so the next bundle starts from the same resolved versions
+# This avoids unwanted dependency upgrades
+cp Gemfile.lock Gemfile.next.lock
+
 # Install next version dependencies
-next bundle install
-```
-
-If `next bundle install` does not work (e.g., the `next` command is not found in PATH), use:
-
-```bash
 BUNDLE_GEMFILE=Gemfile.next bundle install
 ```
 


### PR DESCRIPTION
## Summary

- Adds `cp Gemfile.lock Gemfile.next.lock` before running `BUNDLE_GEMFILE=Gemfile.next bundle install` in the setup workflow
- Ensures only the upgraded dependency (and its transitive deps) changes, avoiding unwanted upgrades of unrelated gems
- Updates SKILL.md setup summary to match

Closes #1

## Test plan

- [ ] Verify setup workflow Step 5 copies the lock file before installing next dependencies
- [ ] Verify SKILL.md setup summary reflects the new step

🤖 Generated with [Claude Code](https://claude.ai/claude-code)