### PR TITLE
Add CHANGELOG.md and align SKILL.md with rails-upgrade

### DIFF
--- a/dual-boot/CHANGELOG.md
+++ b/dual-boot/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## v1.0 — March 2025
+- Initial release as standalone skill (extracted from `rails-upgrade` skill)
+- Setup workflow for dual-boot using `next_rails` gem
+- Cleanup workflow for post-upgrade removal
+- Reference materials: code patterns, CI configuration, Gemfile examples
+- Critical gotcha: always use `NextRails.next?`, never `respond_to?`
+- Added `/dual-boot` slash command with version argument support

--- a/dual-boot/SKILL.md
+++ b/dual-boot/SKILL.md
@@ -6,14 +6,12 @@ argument-hint: "[current-version] [target-version]"
 
 When invoked via `/dual-boot`, follow the setup workflow in `workflows/setup-workflow.md` to set up dual-boot for this project. If the user provides version arguments (e.g. `/dual-boot 7.0 7.1`), use them as the current and target versions. If no arguments are provided, detect the current version from the Gemfile and ask the user for the target version.
 
-# Dual-Boot Skill v1.0
+# Dual-Boot Skill
 
-## Skill Identity
-- **Name:** Dual-Boot
-- **Version:** 1.0
 - **Purpose:** Set up and manage dual-boot environments for Rails, Ruby, or core Gemfile dependencies using the `next_rails` gem
 - **Based on:** FastRuby.io methodology and "The Complete Guide to Upgrade Rails" ebook
 - **Key Gem:** [next_rails](https://github.com/fastruby/next_rails)
+- **Changelog:** See `CHANGELOG.md` for version history
 
 ---
 
@@ -179,9 +177,3 @@ See `workflows/cleanup-workflow.md` for the complete post-upgrade cleanup proces
 | `BUNDLE_GEMFILE=Gemfile.next bundle exec rails server` | Start server with next version |
 | `BUNDLE_GEMFILE=Gemfile.next bundle exec rspec` | Alternative to `next` command |
 
----
-
-**Version:** 1.0
-**Last Updated:** March 2025
-**Methodology:** Based on FastRuby.io upgrade best practices and "The Complete Guide to Upgrade Rails" ebook
-**Attribution:** Content based on "The Complete Guide to Upgrade Rails" by FastRuby.io (OmbuLabs)

--- a/dual-boot/SKILL.md
+++ b/dual-boot/SKILL.md
@@ -9,9 +9,9 @@ When invoked via `/dual-boot`, follow the setup workflow in `workflows/setup-wor
 # Dual-Boot Skill
 
 - **Purpose:** Set up and manage dual-boot environments for Rails, Ruby, or core Gemfile dependencies using the `next_rails` gem
-- **Based on:** FastRuby.io methodology and "The Complete Guide to Upgrade Rails" ebook
 - **Key Gem:** [next_rails](https://github.com/fastruby/next_rails)
-- **Changelog:** See `CHANGELOG.md` for version history
+- **Methodology:** Based on FastRuby.io upgrade best practices and "The Complete Guide to Upgrade Rails" ebook
+- **Attribution:** Content based on "The Complete Guide to Upgrade Rails" by FastRuby.io (OmbuLabs)
 
 ---
 
@@ -176,4 +176,8 @@ See `workflows/cleanup-workflow.md` for the complete post-upgrade cleanup proces
 | `next bundle exec rspec` | Run tests with the next dependency set |
 | `BUNDLE_GEMFILE=Gemfile.next bundle exec rails server` | Start server with next version |
 | `BUNDLE_GEMFILE=Gemfile.next bundle exec rspec` | Alternative to `next` command |
+
+---
+
+See [CHANGELOG.md](CHANGELOG.md) for version history and current version.
 


### PR DESCRIPTION
## Summary

- Add `CHANGELOG.md` to track version history, matching the approach used in the rails-upgrade skill
- Remove duplicate version/date mentions from `SKILL.md` to prevent mismatches
- Align `SKILL.md` structure with rails-upgrade: methodology/attribution at top, changelog reference at bottom

## Changes

- New `dual-boot/CHANGELOG.md` with v1.0 entry
- `dual-boot/SKILL.md`: removed inline version number from heading and footer, added methodology/attribution to identity block, added changelog footer link

## Test plan

- [ ] Verify SKILL.md renders correctly
- [ ] Verify CHANGELOG.md content matches current v1.0 state
- [ ] Compare structure with rails-upgrade SKILL.md for consistency
