### PR TITLE
Add Claude Code plugin manifest

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "dual-boot",
+  "version": "1.0.0",
+  "description": "Sets up and manages dual-boot Ruby and Rails environments using the next_rails gem, based on FastRuby.io methodology",
+  "skills": "./dual-boot/",
+  "author": {
+    "name": "OmbuLabs",
+    "url": "https://github.com/ombulabs"
+  },
+  "repository": "https://github.com/ombulabs/claude-code_dual-boot-skill",
+  "license": "MIT",
+  "keywords": ["rails", "ruby", "dual-boot", "upgrade", "next_rails"]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   },
   "repository": "https://github.com/ombulabs/claude-code_dual-boot-skill",
   "license": "MIT",
-  "keywords": ["rails", "ruby", "dual-boot", "upgrade", "next_rails"]
+  "keywords": ["ruby", "rails", "upgrade", "migration", "fastruby", "breaking-changes", "tech-debt", "deprecations", "legacy-code", "ruby-on-rails", "dual-boot", "next_rails"]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -9,5 +9,18 @@
   },
   "repository": "https://github.com/ombulabs/claude-code_dual-boot-skill",
   "license": "MIT",
-  "keywords": ["ruby", "rails", "upgrade", "migration", "fastruby", "breaking-changes", "tech-debt", "deprecations", "legacy-code", "ruby-on-rails", "dual-boot", "next_rails"]
+  "keywords": [
+    "ruby",
+    "rails",
+    "upgrade",
+    "migration",
+    "fastruby",
+    "breaking-changes",
+    "tech-debt",
+    "deprecations",
+    "legacy-code",
+    "ruby-on-rails",
+    "dual-boot",
+    "next_rails"
+  ]
 }

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Dual-booting is a core part of the [FastRuby.io](https://fastruby.io) upgrade me
 
 ```bash
 claude plugin marketplace add https://github.com/ombulabs/claude-skills.git
-claude plugin install dual-boot@ombulabs-skills
+claude plugin install dual-boot@ombulabs-ai
 ```
 
 **Manual install:**

--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ git clone https://github.com/ombulabs/claude-code_dual-boot-skill.git
 cp -r claude-code_dual-boot-skill/dual-boot ~/.claude/skills/
 ```
 
+> [!NOTE]
+> This skill works standalone, but it is part of the full Rails upgrade toolkit. You may also want to install [rails-load-defaults](https://github.com/ombulabs/claude-code_rails-load-defaults-skill) and [rails-upgrade](https://github.com/ombulabs/claude-code_rails-upgrade-skill).
+
 ### Basic Usage
 
 In Claude Code, navigate to your Rails application directory and use natural language:

--- a/README.md
+++ b/README.md
@@ -29,11 +29,17 @@ Dual-booting is a core part of the [FastRuby.io](https://fastruby.io) upgrade me
 
 ### Installation
 
-```bash
-# Clone the repository
-git clone https://github.com/ombulabs/claude-code_dual-boot-skill.git
+**Via the OmbuLabs marketplace (recommended):**
 
-# Add to your Claude Code skills directory
+```bash
+claude plugin marketplace add https://github.com/ombulabs/claude-skills.git
+claude plugin install dual-boot@ombulabs-skills
+```
+
+**Manual install:**
+
+```bash
+git clone https://github.com/ombulabs/claude-code_dual-boot-skill.git
 cp -r claude-code_dual-boot-skill/dual-boot ~/.claude/skills/
 ```
 


### PR DESCRIPTION
## Summary

- Adds `.claude-plugin/plugin.json` so this repo can be installed as a Claude Code plugin
- Uses the `skills` field to point to the existing `dual-boot/` directory, no file restructuring needed
- Part of the OmbuLabs skills marketplace setup (ombulabs/claude-skills)

## Context

We are setting up an OmbuLabs marketplace (`ombulabs/claude-skills`) that will reference this repo via git URL. This manifest is required for Claude Code to recognize the repo as a plugin.

## Test plan

- [ ] Install locally with `claude --plugin-dir ./` and verify `/dual-boot:dual-boot` is available
- [ ] Confirm SKILL.md is loaded correctly when the skill is invoked