### PR TITLE
docs: add plugin-based install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,14 @@ Dual-booting is a core part of the [FastRuby.io](https://fastruby.io) upgrade me
 
 ### Installation
 
-**Via the OmbuLabs marketplace (recommended):**
+**From inside the Claude Code CLI prompt (recommended):**
+
+```
+/plugin marketplace add ombulabs/claude-skills
+/plugin install dual-boot@ombulabs-ai
+```
+
+**From your terminal:**
 
 ```bash
 claude plugin marketplace add https://github.com/ombulabs/claude-skills.git


### PR DESCRIPTION
## Summary

Updates the README `Installation` section to show the new plugin-based install flows now that this skill ships via the [`ombulabs/claude-skills`](https://github.com/ombulabs/claude-skills) marketplace.

Three install paths are documented:

1. **From inside the Claude Code CLI prompt** (recommended):
   ```
   /plugin marketplace add ombulabs/claude-skills
   /plugin install <skill-name>@ombulabs-ai
   ```
2. **From your terminal:**
   ```bash
   claude plugin marketplace add https://github.com/ombulabs/claude-skills.git
   claude plugin install <skill-name>@ombulabs-ai
   ```
3. **Manual install** (kept for users who don't want the plugin system).

## Test plan

- [ ] Open README preview and confirm both code blocks render correctly
- [ ] Run `/plugin marketplace add ombulabs/claude-skills` then `/plugin install <skill-name>@ombulabs-ai` inside Claude Code
- [ ] Run the terminal equivalent and confirm install succeeds
