### PR TITLE
Clarify next_rails must be at Gemfile root; exclude load_defaults from dual-boot

### DIFF
--- a/dual-boot/workflows/setup-workflow.md
+++ b/dual-boot/workflows/setup-workflow.md
@@ -43,12 +43,20 @@ ls -la Gemfile.next
 
 ## Step 2: Add `next_rails` Gem
 
-Add the gem to the Gemfile (all environments, not just development):
+Add the gem to the Gemfile **at the root level, not inside any group**:
 
 ```ruby
 # Gemfile
 gem 'next_rails'
 ```
+
+**⚠️ If the gem is already present, verify its location.** Grep for it:
+
+```bash
+grep -n "next_rails" Gemfile
+```
+
+If it lives inside a `group :development`, `group :test`, or `group :development, :test do ... end` block, move it outside. Any `NextRails.next?` in `config/environments/production.rb` or `config/application.rb` will raise `NameError: uninitialized constant NextRails` when the app boots in production (e.g., during `assets:precompile RAILS_ENV=production`). The gem must be loadable in every environment where conditional config runs.
 
 Then install:
 
@@ -73,6 +81,8 @@ This creates:
 ## Step 4: Configure Gemfile with Version Conditionals
 
 The `next_rails` gem adds a `next?` helper method to your Gemfile. Use it to specify different versions of the dependency you are upgrading.
+
+**Do not dual-boot `config.load_defaults`.** It is post-upgrade work (rails-upgrade Step 10 / rails-load-defaults skill).
 
 ### Example: Rails version upgrade
 


### PR DESCRIPTION
## Summary

Two clarifications to `dual-boot/workflows/setup-workflow.md` captured from running the skill on a real app:

- **Step 2 — `next_rails` location:** Tightened "all environments, not just development" to "at the root level, not inside any group." Added a verify sub-step: if the gem is already present, grep it and move out of any `:development`/`:test` group. Otherwise `NextRails.next?` in production-mode config (`config/environments/production.rb`, `config/application.rb`) raises `NameError: uninitialized constant NextRails` during e.g. `assets:precompile RAILS_ENV=production`.
- **Step 4 — don't dual-boot `load_defaults`:** One-line fence. `load_defaults` alignment is post-upgrade work handled by `rails-upgrade` Step 10 / `rails-load-defaults` skill. Without this fence, it's easy to reach for `NextRails.next?` as a universal version-mismatch hammer.

## Test plan

- [ ] Step 2 reads coherently; the verify sub-step is actionable
- [ ] Step 4 one-liner is clear without needing the gotcha background