### PR TITLE
docs/add claude md 2

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,103 @@
+# CLAUDE.md
+
+This file guides Claude Code when working in **this repository**. This repo is the
+source for the `dual-boot` Claude Code skill — a plugin that helps end users set up
+and manage dual-boot Ruby/Rails environments with the [`next_rails`](https://github.com/fastruby/next_rails)
+gem.
+
+When Claude is invoked here, the task is almost always to **author, maintain, or
+enhance the skill itself** — not to perform a Rails upgrade on some host app.
+
+---
+
+## What this repository is
+
+A packaged Claude Code skill distributed as a plugin. The skill's authoring surface
+lives in `dual-boot/`:
+
+- `dual-boot/SKILL.md` — skill entry point and trigger patterns (authoritative)
+- `dual-boot/workflows/` — step-by-step procedures (`setup-workflow.md`, `cleanup-workflow.md`)
+- `dual-boot/references/` — supporting docs (code patterns, CI, Gemfile examples, deprecation tracking)
+- `dual-boot/examples/` — worked examples
+- `dual-boot/CHANGELOG.md` — version history
+
+Top-level files:
+
+- `.claude-plugin/plugin.json` — plugin manifest
+- `README.md` — user-facing install + usage
+- `LICENSE`
+
+---
+
+## Scope: stay inside the dual-boot boundary
+
+This skill is part of a three-skill FastRuby.io toolkit. Each skill owns a distinct
+concern, and **this repo must not grow guidance that belongs to the siblings.**
+
+**In scope for this skill:**
+- Installing/configuring the `next_rails` gem
+- Gemfile conventions for two dependency sets (Rails, Ruby, or any core gem)
+- `NextRails.next?` branching patterns in application code
+- CI wiring for both dependency sets (GitHub Actions, CircleCI, Jenkins)
+- `Gemfile.next` / `Gemfile.next.lock` lifecycle
+- Cleanup after the upgrade lands
+- Deprecation-warning visibility (because silenced warnings make dual-boot useless)
+
+**Out of scope — belongs to sibling skills, do NOT add here:**
+- Rails version-specific breaking changes, deprecations, or migration steps → [rails-upgrade](https://github.com/ombulabs/claude-code_rails-upgrade-skill)
+- `app:update` guidance, per-version upgrade reports, detection scripts → rails-upgrade
+- Walking `config.load_defaults` forward, `new_framework_defaults_*.rb` handling,
+  per-config risk tiers, initializer consolidation → [rails-load-defaults](https://github.com/ombulabs/claude-code_rails-load-defaults-skill)
+- Gem compatibility resolution, monkeypatch debugging, time estimates, LTS upgrades
+
+If a task drifts toward upgrade mechanics or `load_defaults` mechanics, stop and
+redirect: either point the work at the correct sibling repo, or — if a cross-link
+is genuinely needed here — keep it to a one-line reference, not embedded content.
+
+When in doubt: this skill answers "how do I run two versions side by side?", not
+"which version should I go to or what breaks when I get there?"
+
+---
+
+## Invariants this skill teaches (and must not contradict)
+
+These are load-bearing across the skill's content. If edits would weaken or
+contradict any of them, stop and surface the conflict instead of shipping.
+
+1. **Use `NextRails.next?`, never `respond_to?`** for version branching. See
+   `dual-boot/SKILL.md` for the rationale.
+2. **Never run `next_rails --init` if `Gemfile.next` already exists** — it duplicates
+   the `next?` method.
+3. **Add `next_rails` at the Gemfile root**, not inside a `:development` or `:test` group.
+4. **Keep the `NextRails.next?` (true) branch on top**, `else` (current version) below.
+5. **Cleanup preserves `Gemfile.next.lock` versions** — replace `Gemfile.lock` with
+   `Gemfile.next.lock`, don't re-resolve.
+6. **Deprecation warnings must stay visible** during dual-boot.
+
+---
+
+## Working conventions
+
+- **Edit existing files over creating new ones.** The skill's shape is intentional;
+  new top-level files or new `references/` entries should be justified.
+- **SKILL.md is the entry point** — if you add a workflow or reference, link it from
+  SKILL.md's "Available Resources" section so Claude can discover it at runtime.
+- **Trigger patterns matter.** New user phrasings that should activate the skill go
+  in SKILL.md's "Trigger Patterns" section.
+- **Update `dual-boot/CHANGELOG.md`** for user-visible changes to the skill.
+- **Keep examples runnable and minimal.** Don't invent app-specific detail users
+  won't have.
+- **Don't add emojis** unless the surrounding file already uses them.
+
+---
+
+## Validation before proposing changes
+
+There is no automated test suite. Before opening a PR:
+
+- Re-read the edited file end-to-end — the skill is prose, and coherence is the test.
+- Cross-check any referenced path (`workflows/...`, `references/...`) actually exists.
+- If you changed a workflow step, walk the full workflow mentally against a fresh
+  Rails app to confirm the steps still compose.
+- Confirm nothing you added belongs in rails-upgrade or rails-load-defaults (see
+  "Scope" above).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,12 +1,12 @@
 # CLAUDE.md
 
 This file guides Claude Code when working in **this repository**. This repo is the
-source for the `dual-boot` Claude Code skill — a plugin that helps end users set up
+source for the `dual-boot` Claude Code skill, a plugin that helps end users set up
 and manage dual-boot Ruby/Rails environments with the [`next_rails`](https://github.com/fastruby/next_rails)
 gem.
 
 When Claude is invoked here, the task is almost always to **author, maintain, or
-enhance the skill itself** — not to perform a Rails upgrade on some host app.
+enhance the skill itself**, not to perform a Rails upgrade on some host app.
 
 ---
 
@@ -15,16 +15,16 @@ enhance the skill itself** — not to perform a Rails upgrade on some host app.
 A packaged Claude Code skill distributed as a plugin. The skill's authoring surface
 lives in `dual-boot/`:
 
-- `dual-boot/SKILL.md` — skill entry point and trigger patterns (authoritative)
-- `dual-boot/workflows/` — step-by-step procedures (`setup-workflow.md`, `cleanup-workflow.md`)
-- `dual-boot/references/` — supporting docs (code patterns, CI, Gemfile examples, deprecation tracking)
-- `dual-boot/examples/` — worked examples
-- `dual-boot/CHANGELOG.md` — version history
+- `dual-boot/SKILL.md`: skill entry point and trigger patterns (authoritative)
+- `dual-boot/workflows/`: step-by-step procedures (`setup-workflow.md`, `cleanup-workflow.md`)
+- `dual-boot/references/`: supporting docs (code patterns, CI, Gemfile examples, deprecation tracking)
+- `dual-boot/examples/`: worked examples
+- `dual-boot/CHANGELOG.md`: version history
 
 Top-level files:
 
-- `.claude-plugin/plugin.json` — plugin manifest
-- `README.md` — user-facing install + usage
+- `.claude-plugin/plugin.json`: plugin manifest
+- `README.md`: user-facing install + usage
 - `LICENSE`
 
 ---
@@ -43,16 +43,16 @@ concern, and **this repo must not grow guidance that belongs to the siblings.**
 - Cleanup after the upgrade lands
 - Deprecation-warning visibility (because silenced warnings make dual-boot useless)
 
-**Out of scope — belongs to sibling skills, do NOT add here:**
-- Rails version-specific breaking changes, deprecations, or migration steps → [rails-upgrade](https://github.com/ombulabs/claude-code_rails-upgrade-skill)
-- `app:update` guidance, per-version upgrade reports, detection scripts → rails-upgrade
+**Out of scope, belongs to sibling skills, do NOT add here:**
+- Rails version-specific breaking changes, deprecations, or migration steps: see [rails-upgrade](https://github.com/ombulabs/claude-code_rails-upgrade-skill)
+- `app:update` guidance, per-version upgrade reports, detection scripts: see rails-upgrade
 - Walking `config.load_defaults` forward, `new_framework_defaults_*.rb` handling,
-  per-config risk tiers, initializer consolidation → [rails-load-defaults](https://github.com/ombulabs/claude-code_rails-load-defaults-skill)
+  per-config risk tiers, initializer consolidation: see [rails-load-defaults](https://github.com/ombulabs/claude-code_rails-load-defaults-skill)
 - Gem compatibility resolution, monkeypatch debugging, time estimates, LTS upgrades
 
 If a task drifts toward upgrade mechanics or `load_defaults` mechanics, stop and
-redirect: either point the work at the correct sibling repo, or — if a cross-link
-is genuinely needed here — keep it to a one-line reference, not embedded content.
+redirect: either point the work at the correct sibling repo, or, if a cross-link
+is genuinely needed here, keep it to a one-line reference, not embedded content.
 
 When in doubt: this skill answers "how do I run two versions side by side?", not
 "which version should I go to or what breaks when I get there?"
@@ -64,19 +64,17 @@ When in doubt: this skill answers "how do I run two versions side by side?", not
 These are load-bearing across the skill's content. If edits would weaken or
 contradict any of them, stop and surface the conflict instead of shipping.
 
-1. **Branch with `next_rails`, never with `respond_to?`.** The gem exposes both
-   `NextRails.next?` and `NextRails.current?` — either is fine, but a given
-   codebase should pick **one** and apply it consistently so readers don't have
-   to mentally flip the polarity of each check. See `dual-boot/SKILL.md` for the
-   rationale on why `respond_to?` is the wrong tool.
-2. **Never run `next_rails --init` if `Gemfile.next` already exists** — it duplicates
+1. **Branch with `NextRails.next?`, never with `respond_to?` or `NextRails.current?`.**
+   The skill teaches `next?` exclusively so the post-upgrade cleanup is a mechanical
+   search-and-delete of the truthy branch. Mixing `current?` inverts the polarity
+   and breaks that cleanup contract. See `dual-boot/SKILL.md` for the rationale on
+   why `respond_to?` is also the wrong tool.
+2. **Never run `next_rails --init` if `Gemfile.next` already exists**, it duplicates
    the `next?` method.
 3. **Add `next_rails` at the Gemfile root**, not inside a `:development` or `:test` group.
-4. **Order branches so the "next version" case reads on top.** With
-   `NextRails.next?`, that means the `if` branch is next-version code and `else`
-   is current-version code; with `NextRails.current?`, invert the branches so the
-   next-version code still appears first.
-5. **Cleanup preserves `Gemfile.next.lock` versions** — replace `Gemfile.lock` with
+4. **Order branches so the "next version" case reads on top**: the `if NextRails.next?`
+   branch is next-version code, the `else` is current-version code.
+5. **Cleanup preserves `Gemfile.next.lock` versions**: replace `Gemfile.lock` with
    `Gemfile.next.lock`, don't re-resolve.
 6. **Deprecation warnings must stay visible** during dual-boot.
 
@@ -86,7 +84,7 @@ contradict any of them, stop and surface the conflict instead of shipping.
 
 - **Edit existing files over creating new ones.** The skill's shape is intentional;
   new top-level files or new `references/` entries should be justified.
-- **SKILL.md is the entry point** — if you add a workflow or reference, link it from
+- **SKILL.md is the entry point**: if you add a workflow or reference, link it from
   SKILL.md's "Available Resources" section so Claude can discover it at runtime.
 - **Trigger patterns matter.** New user phrasings that should activate the skill go
   in SKILL.md's "Trigger Patterns" section.
@@ -101,7 +99,7 @@ contradict any of them, stop and surface the conflict instead of shipping.
 
 There is no automated test suite. Before opening a PR:
 
-- Re-read the edited file end-to-end — the skill is prose, and coherence is the test.
+- Re-read the edited file end-to-end: the skill is prose, and coherence is the test.
 - Cross-check any referenced path (`workflows/...`, `references/...`) actually exists.
 - If you changed a workflow step, walk the full workflow mentally against a fresh
   Rails app to confirm the steps still compose.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ concern, and **this repo must not grow guidance that belongs to the siblings.**
 **In scope for this skill:**
 - Installing/configuring the `next_rails` gem
 - Gemfile conventions for two dependency sets (Rails, Ruby, or any core gem)
-- `NextRails.next?` branching patterns in application code
+- `NextRails.next?` / `NextRails.current?` branching patterns in application code
 - CI wiring for both dependency sets (GitHub Actions, CircleCI, Jenkins)
 - `Gemfile.next` / `Gemfile.next.lock` lifecycle
 - Cleanup after the upgrade lands
@@ -64,12 +64,18 @@ When in doubt: this skill answers "how do I run two versions side by side?", not
 These are load-bearing across the skill's content. If edits would weaken or
 contradict any of them, stop and surface the conflict instead of shipping.
 
-1. **Use `NextRails.next?`, never `respond_to?`** for version branching. See
-   `dual-boot/SKILL.md` for the rationale.
+1. **Branch with `next_rails`, never with `respond_to?`.** The gem exposes both
+   `NextRails.next?` and `NextRails.current?` — either is fine, but a given
+   codebase should pick **one** and apply it consistently so readers don't have
+   to mentally flip the polarity of each check. See `dual-boot/SKILL.md` for the
+   rationale on why `respond_to?` is the wrong tool.
 2. **Never run `next_rails --init` if `Gemfile.next` already exists** — it duplicates
    the `next?` method.
 3. **Add `next_rails` at the Gemfile root**, not inside a `:development` or `:test` group.
-4. **Keep the `NextRails.next?` (true) branch on top**, `else` (current version) below.
+4. **Order branches so the "next version" case reads on top.** With
+   `NextRails.next?`, that means the `if` branch is next-version code and `else`
+   is current-version code; with `NextRails.current?`, invert the branches so the
+   next-version code still appears first.
 5. **Cleanup preserves `Gemfile.next.lock` versions** — replace `Gemfile.lock` with
    `Gemfile.next.lock`, don't re-resolve.
 6. **Deprecation warnings must stay visible** during dual-boot.

--- a/dual-boot/SKILL.md
+++ b/dual-boot/SKILL.md
@@ -169,7 +169,7 @@ See `workflows/cleanup-workflow.md` for the complete post-upgrade cleanup proces
 1. **Ensure deprecation warnings are visible** — silenced deprecations mean you can't track upgrade progress
 2. **Never run `next_rails --init` if `Gemfile.next` exists** — it will duplicate the `next?` method
 3. **Always use `NextRails.next?` for version-dependent code** — never `respond_to?`
-4. **Test both versions** — run `bundle exec rspec` and `BUNDLE_GEMFILE=Gemfile.next bundle exec rspec`
+4. **Test both versions using the project's own test runner.** Detect it before running anything: check the `Gemfile` for `rspec-rails`, `parallel_tests`, `turbo_tests`, or `minitest-parallel_fork`, check whether the app has `spec/` or `test/`, and prefer wrappers like `bin/test` when they exist. Every `bundle exec rspec` in the workflows, examples, and CI reference is illustrative; substitute the detected command (e.g. `bin/rails test`, `bundle exec parallel_rspec spec/`, `bin/test`) and prefix with `BUNDLE_GEMFILE=Gemfile.next` (or the `next` CLI) to run it against the next dependency set.
 5. **Clean up after upgrade** — search for and remove all `NextRails.next?` branches
 6. **Add `next_rails` at the Gemfile root level** — not inside a `:development` or `:test` group
 

--- a/dual-boot/references/ci-configuration.md
+++ b/dual-boot/references/ci-configuration.md
@@ -2,6 +2,22 @@
 
 Run your test suite against both dependency sets in CI. These examples use `BUNDLE_GEMFILE=Gemfile.next` to switch between the current and next dependency sets — this works the same whether you are upgrading Rails, Ruby, or another core gem.
 
+## Test Command
+
+Every example below runs `bundle exec rspec` as a stand-in. Detect and substitute the project's actual command everywhere you see it:
+
+| Runner | Command |
+|---|---|
+| RSpec | `bundle exec rspec` |
+| Minitest (Rails) | `bin/rails test` |
+| Minitest (rake) | `bundle exec rake test` |
+| parallel_tests (RSpec) | `bundle exec parallel_rspec spec/` |
+| parallel_tests (Minitest) | `bundle exec parallel_test test/` |
+| turbo_tests | `bundle exec turbo_tests` |
+| Project wrapper | `bin/test` / `bin/ci` (prefer when present) |
+
+The matrix / job structure in each CI example is runner-agnostic — only the single "run tests" line needs swapping.
+
 ---
 
 ## GitHub Actions
@@ -49,7 +65,7 @@ jobs:
           bundle exec rails db:schema:load
 
       - name: Run Tests
-        run: bundle exec rspec
+        run: bundle exec rspec  # Minitest: bin/rails test  |  wrapper: bin/test
 ```
 
 ---
@@ -73,7 +89,7 @@ jobs:
       - checkout
       - run: bundle install
       - run: bundle exec rails db:create db:schema:load
-      - run: bundle exec rspec
+      - run: bundle exec rspec  # Minitest: bin/rails test  |  wrapper: bin/test
 
   build-next:
     docker:
@@ -87,7 +103,7 @@ jobs:
       - checkout
       - run: bundle install
       - run: bundle exec rails db:create db:schema:load
-      - run: bundle exec rspec
+      - run: bundle exec rspec  # Minitest: bin/rails test  |  wrapper: bin/test
 
 workflows:
   version: 2
@@ -122,7 +138,7 @@ pipeline {
 
     stage('Test Current') {
       steps {
-        sh 'bundle exec rspec'
+        sh 'bundle exec rspec'  // Minitest: bin/rails test  |  wrapper: bin/test
       }
     }
 
@@ -133,7 +149,7 @@ pipeline {
       steps {
         sh 'bundle install'
         sh 'bundle exec rails db:create db:schema:load'
-        sh 'bundle exec rspec'
+        sh 'bundle exec rspec'  // Minitest: bin/rails test  |  wrapper: bin/test
       }
     }
   }

--- a/dual-boot/references/deprecation-tracking.md
+++ b/dual-boot/references/deprecation-tracking.md
@@ -70,10 +70,11 @@ Ensure `next_rails` is in your Gemfile at the **root level** (not inside a `grou
 gem 'next_rails'
 ```
 
-Then configure RSpec:
+Then configure your test runner.
+
+**RSpec** — in `spec/spec_helper.rb` (or `spec/rails_helper.rb`):
 
 ```ruby
-# spec/spec_helper.rb (or spec/rails_helper.rb)
 RSpec.configure do |config|
   DeprecationTracker.track_rspec(
     config,
@@ -84,13 +85,23 @@ RSpec.configure do |config|
 end
 ```
 
+**Minitest** — in `test/test_helper.rb`:
+
+```ruby
+DeprecationTracker.track_minitest(
+  shitlist_path: "test/support/deprecation_warning.shitlist.json",
+  mode: ENV.fetch("DEPRECATION_TRACKER", "save"),
+  transform_message: -> (message) { message.gsub("#{Rails.root}/", "") }
+)
+```
+
 - **`shitlist_path`** — where to save/read the deprecation inventory (required, no default)
 - **`mode`** — defaults to `save` so it always tracks
 - **`transform_message`** — strips the Rails root path from messages so the shitlist is portable across environments
 
 ### Save the Deprecation Shitlist
 
-Run the test suite with `DEPRECATION_TRACKER=save` to collect all deprecation warnings:
+Run the test suite with `DEPRECATION_TRACKER=save` to collect all deprecation warnings (substitute your project's test command — e.g. `bundle exec rspec`, `bin/rails test`, `bin/test`):
 
 ```bash
 DEPRECATION_TRACKER=save bundle exec rspec
@@ -98,7 +109,7 @@ DEPRECATION_TRACKER=save bundle exec rspec
 
 This generates `spec/support/deprecation_warning.shitlist.json` — a JSON file listing every unique deprecation warning found during the run.
 
-> **Note:** The shitlist path is hardcoded to `spec/support/deprecation_warning.shitlist.json`. Make sure this directory exists.
+> **Note:** Make sure the directory for `shitlist_path` exists before running.
 
 ### Prevent Regressions
 
@@ -153,9 +164,8 @@ The exact collection mechanism depends on your CI setup:
 ### Limitations
 
 - **Not compatible with `minitest/parallel_fork`** — use standard minitest or RSpec
-- **Shitlist path is hardcoded** — must be `spec/support/deprecation_warning.shitlist.json`
 - **No native parallel support** — requires manual merge when using CI parallelism (see above)
-- **RSpec only** for the `track_rspec` helper — Minitest requires manual integration
+- **Supports RSpec (`track_rspec`) and Minitest (`track_minitest`)** — other frameworks require manual integration
 
 ---
 

--- a/dual-boot/workflows/cleanup-workflow.md
+++ b/dual-boot/workflows/cleanup-workflow.md
@@ -97,8 +97,19 @@ mv Gemfile.next.lock Gemfile.lock
 
 ## Step 6: Run Full Test Suite
 
+Run the project's detected test command (see SKILL.md Key Principle #4). Pick the one that matches this project:
+
 ```bash
+# RSpec
 bundle exec rspec
+
+# Minitest
+bin/rails test
+
+# Or a project wrapper / parallel runner
+bin/test
+bundle exec parallel_rspec spec/
+bundle exec turbo_tests
 ```
 
 Ensure all tests pass without dual-boot.

--- a/dual-boot/workflows/setup-workflow.md
+++ b/dual-boot/workflows/setup-workflow.md
@@ -169,6 +169,10 @@ BUNDLE_GEMFILE=Gemfile.next bundle install
 
 ## Step 6: Verify Both Dependency Sets Work
 
+Use the project's own test runner. Detect it first: `rspec-rails` in the Gemfile and a `spec/` directory → RSpec; `test/` and no `spec/` → Minitest; a `bin/test` wrapper → prefer it; `parallel_tests` / `turbo_tests` → use their binaries.
+
+### RSpec
+
 ```bash
 # Run tests with current version
 bundle exec rspec
@@ -176,6 +180,18 @@ bundle exec rspec
 # Run tests with next version
 BUNDLE_GEMFILE=Gemfile.next bundle exec rspec
 ```
+
+### Minitest
+
+```bash
+# Run tests with current version
+bin/rails test
+
+# Run tests with next version
+BUNDLE_GEMFILE=Gemfile.next bin/rails test
+```
+
+If the project uses `rake test` instead of `bin/rails test`, or a parallel runner (`parallel_rspec`, `parallel_test`, `turbo_tests`), substitute that binary — the `BUNDLE_GEMFILE=Gemfile.next` prefix (or the `next` CLI) works with any of them.
 
 ---
 
@@ -205,6 +221,20 @@ DEPRECATION_TRACKER=save bundle exec rspec
 ```
 
 This creates `spec/support/deprecation_warning.shitlist.json` — a JSON file listing every unique deprecation warning found during the run. Review it to understand the scope of deprecations you need to address.
+
+### Minitest
+
+For Minitest apps, use `DeprecationTracker.track_minitest` in `test/test_helper.rb`:
+
+```ruby
+DeprecationTracker.track_minitest(
+  shitlist_path: "test/support/deprecation_warning.shitlist.json",
+  mode: ENV.fetch("DEPRECATION_TRACKER", "save"),
+  transform_message: -> (message) { message.gsub("#{Rails.root}/", "") }
+)
+```
+
+Then generate the inventory with `DEPRECATION_TRACKER=save bin/rails test`. If `track_minitest` doesn't fit your setup (e.g., `minitest/parallel_fork`), fall back to the custom deprecation behavior approach in `references/deprecation-tracking.md` (Step 3).
 
 See `references/deprecation-tracking.md` for the full workflow (updating the shitlist, preventing regressions, CI with parallel execution, and alternative approaches).
 


### PR DESCRIPTION
## Summary

Follow-up on the review of the original `docs/add-claude-md` PR. Resolves drift between `CLAUDE.md` and `dual-boot/SKILL.md` and removes em dashes per global style rule.

## Why

### Invariant #1: `next?`-only, `current?` now banned

Previous text said `NextRails.next?` *or* `NextRails.current?` was fine as long as a codebase picked one. That directly contradicted `dual-boot/SKILL.md` (sections "CRITICAL: Always Use `NextRails.next?`", Workflow step 2, Key Points), which teaches `next?` exclusively and never mentions `current?`.

Since `CLAUDE.md` itself says "If edits would weaken or contradict [invariants], stop and surface the conflict," shipping contradictory guidance would have failed the skill's own test. Two ways to fix:

- (a) tighten `CLAUDE.md` back to `next?`-only, or
- (b) loosen `SKILL.md` to allow either.

Picked (a) because:

- The branch scope is `docs/add-claude-md`, so changes stay in `CLAUDE.md`.
- The skill's cleanup story relies on `next?` exclusivity: post-upgrade, cleanup is a mechanical search-and-delete of the truthy branch. Allowing `current?` inverts polarity in some files, so cleanup has to reason per-file instead of blindly.
- Loosening would also require shipping the "branch-ordering inversion" rule to end users (it was only in `CLAUDE.md`), expanding user-facing API surface for no concrete win.

Invariant #1 now explicitly bans `current?` alongside `respond_to?` and states the cleanup-contract rationale.

### Invariant #4: simplified branch ordering

Previous wording carried a `current?`-inversion clause ("with `NextRails.current?`, invert the branches..."). With `current?` banned by #1, that clause is dead weight. Reduced to the single rule: `if NextRails.next?` = next-version code, `else` = current-version code.

### Em dashes removed

Global `AGENTS.md` rule: "Never use em dashes (—) in text output. Use commas, periods, or rewrite the sentence instead." Replaced all occurrences in `CLAUDE.md` with colons or commas. No semantic change.

## Test plan

- [ ] Re-read `CLAUDE.md` end-to-end for coherence.
- [ ] Grep `CLAUDE.md` vs `dual-boot/SKILL.md` for any remaining `current?` vs `next?` contradiction.
- [ ] Confirm no em dashes remain: `rg "—" CLAUDE.md` returns nothing.
- [ ] Verify all referenced paths (`workflows/`, `references/`, `examples/`, `CHANGELOG.md`) still exist.
