### PR TITLE
Replace deprecation examples with genuine breaking changes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ concern, and **this repo must not grow guidance that belongs to the siblings.**
 **In scope for this skill:**
 - Installing/configuring the `next_rails` gem
 - Gemfile conventions for two dependency sets (Rails, Ruby, or any core gem)
-- `NextRails.next?` branching patterns in application code
+- `NextRails.next?` / `NextRails.current?` branching patterns in application code
 - CI wiring for both dependency sets (GitHub Actions, CircleCI, Jenkins)
 - `Gemfile.next` / `Gemfile.next.lock` lifecycle
 - Cleanup after the upgrade lands

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ concern, and **this repo must not grow guidance that belongs to the siblings.**
 **In scope for this skill:**
 - Installing/configuring the `next_rails` gem
 - Gemfile conventions for two dependency sets (Rails, Ruby, or any core gem)
-- `NextRails.next?` / `NextRails.current?` branching patterns in application code
+- `NextRails.next?` branching patterns in application code
 - CI wiring for both dependency sets (GitHub Actions, CircleCI, Jenkins)
 - `Gemfile.next` / `Gemfile.next.lock` lifecycle
 - Cleanup after the upgrade lands
@@ -64,21 +64,23 @@ When in doubt: this skill answers "how do I run two versions side by side?", not
 These are load-bearing across the skill's content. If edits would weaken or
 contradict any of them, stop and surface the conflict instead of shipping.
 
-1. **Branch with `next_rails`, never with `respond_to?`.** The gem exposes both
-   `NextRails.next?` and `NextRails.current?` — either is fine, but a given
-   codebase should pick **one** and apply it consistently so readers don't have
-   to mentally flip the polarity of each check. See `dual-boot/SKILL.md` for the
-   rationale on why `respond_to?` is the wrong tool.
+1. **Branch with `NextRails.next?`, never with `respond_to?`.** The gem also
+   exposes `NextRails.current?`, but this skill standardizes on `NextRails.next?`
+   so all examples, workflows, and user code read with the same polarity. See
+   `dual-boot/SKILL.md` for the rationale on why `respond_to?` is the wrong tool.
 2. **Never run `next_rails --init` if `Gemfile.next` already exists** — it duplicates
    the `next?` method.
 3. **Add `next_rails` at the Gemfile root**, not inside a `:development` or `:test` group.
-4. **Order branches so the "next version" case reads on top.** With
-   `NextRails.next?`, that means the `if` branch is next-version code and `else`
-   is current-version code; with `NextRails.current?`, invert the branches so the
-   next-version code still appears first.
+4. **Order branches so the "next version" case reads on top.** The `if NextRails.next?`
+   branch is next-version code; `else` is current-version code. This makes cleanup
+   mechanical: after the upgrade, keep the `if` branch and drop the `else`.
 5. **Cleanup preserves `Gemfile.next.lock` versions** — replace `Gemfile.lock` with
    `Gemfile.next.lock`, don't re-resolve.
 6. **Deprecation warnings must stay visible** during dual-boot.
+7. **Only branch for genuine breaking changes** — removed constants, removed methods,
+   incompatible signatures. If the new API works on both versions (i.e. the old one
+   merely emits a deprecation warning), migrate the call site directly instead of
+   wrapping it in `NextRails.next?`. See `dual-boot/SKILL.md` "Pattern" section.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -71,14 +71,13 @@ In Claude Code, navigate to your Rails application directory and use natural lan
 When writing code that must work with two versions, always use `NextRails.next?`:
 
 ```ruby
-# app/models/project.rb
-class Project < ActiveRecord::Base
+# spec/requests/projects_spec.rb
+test_request =
   if NextRails.next?
-    self.ignored_columns += [:category]
+    ActionController::TestRequest.create
   else
-    ignore_columns :category
+    ActionController::TestRequest.new
   end
-end
 ```
 
 Never use `respond_to?`, `defined?`, or other feature-detection patterns. They are fragile, hard to clean up, and obscure intent.

--- a/README.md
+++ b/README.md
@@ -66,20 +66,24 @@ In Claude Code, navigate to your Rails application directory and use natural lan
 "Clean up dual-boot code after upgrade"
 ```
 
-## Key Principle: Use `NextRails.next?` (not `respond_to?`!)
+## Key Principle: Use `NextRails.next?` (not feature detection)
 
 When writing code that must work with two versions, always use `NextRails.next?`:
 
 ```ruby
-# CORRECT
-if NextRails.next?
-  config.fixture_paths = ["#{::Rails.root}/spec/fixtures"]
-else
-  config.fixture_path = "#{::Rails.root}/spec/fixtures"
+# app/models/project.rb
+class Project < ActiveRecord::Base
+  if NextRails.next?
+    self.ignored_columns += [:category]
+  else
+    ignore_columns :category
+  end
 end
 ```
 
-Never use `respond_to?` for version branching. It's hard to understand, hard to maintain, and obscures intent.
+Never use `respond_to?`, `defined?`, or other feature-detection patterns. They are fragile, hard to clean up, and obscure intent.
+
+Only branch when the old API genuinely breaks on the next version. A plain deprecation warning is not a reason for a conditional — if the new API works on both versions, just use it directly.
 
 ## Related Skills
 

--- a/dual-boot/CHANGELOG.md
+++ b/dual-boot/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## v1.1 — 22 April 2026
-- Replaced `fixture_path`/`fixture_paths` and `serialize coder:` examples (both are backwards-compat deprecations) with genuine breaking changes (`ActionDispatch::Http::ParameterFilter` removal in Rails 6.1). Added explicit guidance: deprecations should be fixed by direct replacement, not wrapped in `NextRails.next?`. (#2)
+- Replaced the `fixture_path`/`fixture_paths` and `serialize coder:` examples (both backwards-compat deprecations that don't require a conditional) with a genuine breaking change: `ignorable` gem's `ignore_columns` → native `ignored_columns=` at Rails 4.2 → 5.0, where each side's API raises `NoMethodError` on the other. Added explicit guidance that deprecations should be fixed by direct replacement, not wrapped in `NextRails.next?` (SKILL.md "Pattern", `references/code-patterns.md` "When NOT to Branch: Deprecations"). Broadened the "no feature detection" rule to call out `defined?` alongside `respond_to?`. Standardized on `NextRails.next?` polarity across the skill (removed the "`.current?` is also fine" clause from `CLAUDE.md`). Added invariant #7 codifying "only branch for genuine breaking changes". (#2)
 
 ## v1.0 — 04 March 2025
 - Initial release as standalone skill (extracted from `rails-upgrade` skill)

--- a/dual-boot/CHANGELOG.md
+++ b/dual-boot/CHANGELOG.md
@@ -1,7 +1,12 @@
 # Changelog
 
 ## v1.1 — 22 April 2026
-- Replaced the `fixture_path`/`fixture_paths` and `serialize coder:` examples (both backwards-compat deprecations that don't require a conditional) with a genuine breaking change: `ignorable` gem's `ignore_columns` → native `ignored_columns=` at Rails 4.2 → 5.0, where each side's API raises `NoMethodError` on the other. Added explicit guidance that deprecations should be fixed by direct replacement, not wrapped in `NextRails.next?` (SKILL.md "Pattern", `references/code-patterns.md` "When NOT to Branch: Deprecations"). Broadened the "no feature detection" rule to call out `defined?` alongside `respond_to?`. Standardized on `NextRails.next?` polarity across the skill (removed the "`.current?` is also fine" clause from `CLAUDE.md`). Added invariant #7 codifying "only branch for genuine breaking changes". (#2)
+- Replaced the `fixture_path`/`fixture_paths` and `serialize coder:` examples (both backwards-compat deprecations that don't require a conditional) with a genuine breaking change: `ignorable` gem's `ignore_columns` → native `ignored_columns=` at Rails 4.2 → 5.0, where each side's API raises `NoMethodError` on the other. (#2)
+- Added a new "When NOT to Branch: Deprecations" section in `references/code-patterns.md` using `fixture_path` → `fixture_paths` as the counter-example, so readers learn that deprecations are unconditional migrations — not `NextRails.next?` conditionals.
+- Broadened the "no feature detection" rule to call out `defined?` and `const_defined?` alongside `respond_to?`.
+- Standardized on `NextRails.next?` polarity across the skill (removed the "`.current?` is also fine" clause from `CLAUDE.md`).
+- Added invariant #7 in `CLAUDE.md`: only branch for genuine breaking changes.
+- Removed the `session_store` and `Sidekiq` examples that didn't survive invariant #7 — both were either cosmetic config differences (session_store) or ambiguous across intra-major gem versions (`default_worker_options` is a deprecated alias on Sidekiq 6.5+, so the example only held for Sidekiq ≤ 6.4 → 7.0).
 
 ## v1.0 — 04 March 2025
 - Initial release as standalone skill (extracted from `rails-upgrade` skill)

--- a/dual-boot/CHANGELOG.md
+++ b/dual-boot/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
-## v1.1 — 22 April 2026
-- Replaced the `fixture_path`/`fixture_paths` and `serialize coder:` examples (both backwards-compat deprecations that don't require a conditional) with a genuine breaking change: `ignorable` gem's `ignore_columns` → native `ignored_columns=` at Rails 4.2 → 5.0, where each side's API raises `NoMethodError` on the other. (#2)
+## v1.1 — 24 April 2026
+- Swapped the canonical NextRails.next? example across the skill to `ActionController::TestRequest.new` → `TestRequest.create` at Rails 4.2 → 5.0: `new` takes optional `env` on 4.2 but requires 2 non-optional args on 5.0, and `create` doesn't exist on 4.2 — each side raises on the other. Updated SKILL.md, README.md, `references/code-patterns.md`, `workflows/cleanup-workflow.md`, and `examples/basic-setup.md`.
+- Previously replaced the `fixture_path`/`fixture_paths` and `serialize coder:` examples (both backwards-compat deprecations that don't require a conditional) with a genuine breaking change. (#2)
 - Added a new "When NOT to Branch: Deprecations" section in `references/code-patterns.md` using `fixture_path` → `fixture_paths` as the counter-example, so readers learn that deprecations are unconditional migrations — not `NextRails.next?` conditionals.
 - Broadened the "no feature detection" rule to call out `defined?` and `const_defined?` alongside `respond_to?`.
 - Standardized on `NextRails.next?` polarity across the skill (removed the "`.current?` is also fine" clause from `CLAUDE.md`).

--- a/dual-boot/CHANGELOG.md
+++ b/dual-boot/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
-## v1.0 — March 2025
+## v1.1 — 22 April 2026
+- Replaced `fixture_path`/`fixture_paths` and `serialize coder:` examples (both are backwards-compat deprecations) with genuine breaking changes (`ActionDispatch::Http::ParameterFilter` removal in Rails 6.1). Added explicit guidance: deprecations should be fixed by direct replacement, not wrapped in `NextRails.next?`. (#2)
+
+## v1.0 — 04 March 2025
 - Initial release as standalone skill (extracted from `rails-upgrade` skill)
 - Setup workflow for dual-boot using `next_rails` gem
 - Cleanup workflow for post-upgrade removal

--- a/dual-boot/SKILL.md
+++ b/dual-boot/SKILL.md
@@ -46,38 +46,43 @@ When writing code that must work with both the current and target versions, **al
 
 ### Pattern
 
-The right time for a conditional is when the old code actually **breaks** on the next version (removed constant, removed method, incompatible signature) — not when it merely emits a deprecation warning. Deprecations should be fixed by replacing the code outright, since the new form works on both versions.
+Reach for `NextRails.next?` only when the old and new APIs are genuinely **two-sided** — the old one raises on the next version and the new one doesn't exist on the current version. A plain deprecation warning is *not* a reason to branch: if the new API works on both sides, migrate the call site directly.
 
-Example: `ActionDispatch::Http::ParameterFilter` was removed in Rails 6.1 (replaced by `ActiveSupport::ParameterFilter`). Referencing the old constant under 6.1 raises `NameError`, so a conditional is required during 6.0 → 6.1 dual-boot.
-
-❌ **WRONG — Do NOT use feature detection (`defined?`, `respond_to?`, etc.):**
+❌ **WRONG — Do NOT use feature detection (`respond_to?`, `defined?`, etc.):**
 ```ruby
-if defined?(ActiveSupport::ParameterFilter)
-  filter = ActiveSupport::ParameterFilter.new([:password])
+if Project.respond_to?(:ignored_columns=)
+  self.ignored_columns += [:category]
 else
-  filter = ActionDispatch::Http::ParameterFilter.new([:password])
+  ignore_columns :category
 end
 ```
 
 ✅ **CORRECT — Use `NextRails.next?`:**
 ```ruby
-if NextRails.next?
-  filter = ActiveSupport::ParameterFilter.new([:password])
-else
-  filter = ActionDispatch::Http::ParameterFilter.new([:password])
+# app/models/project.rb
+class Project < ActiveRecord::Base
+  if NextRails.next?
+    self.ignored_columns += [:category]
+  else
+    ignore_columns :category
+  end
 end
 ```
+
+This is a genuine two-sided case (Rails 4.2 → 5.0): on 4.2 the app uses the [`ignorable`](https://github.com/nthj/ignorable) gem's `ignore_columns` class method. Rails 5.0 introduced native `ignored_columns=` with different syntax, and once the gem is dropped on the 5.0 side, `ignore_columns` raises `NoMethodError`. `ignored_columns=` raises `NoMethodError` on 4.2 where it doesn't yet exist.
+
+Put the next-version branch on top so cleanup is mechanical: after the upgrade, keep the `if` body and drop the `else`. See `references/code-patterns.md` for more examples.
 
 ### When to Apply
 
 Use `NextRails.next?` branching for:
-- **Removed constants or methods** (e.g., `ActionDispatch::Http::ParameterFilter` removed in Rails 6.1, `update_attributes` removed in Rails 6.1)
-- **Incompatible signature or return-type changes** (e.g., a method that now returns a different object type)
-- **Gem version differences where the old API is gone in the new version** (not just renamed-with-alias)
-- **Initializer changes that break on one side** (e.g., middleware removed from defaults, config key that raises on the other version)
+- **Removed methods or constants** where the replacement only exists on the new side (e.g., a gem-provided method replaced by a native Rails method with different syntax)
+- **Incompatible signature or return-type changes** where the old and new forms genuinely fail on opposite sides
+- **Gem version differences** where the gem's API is different across versions pinned to each Rails version
+- **Initializer changes** where a config or middleware raises on one side
 - **Ruby version differences** (e.g., syntax changes, stdlib removals)
 
-**Not a reason to branch:** deprecation warnings. If the new API works on both versions, migrate the call site directly — do not wrap it in `NextRails.next?`. See `references/code-patterns.md` "When NOT to Branch: Deprecations".
+**Not a reason to branch:** plain deprecation warnings. If the new API works on both versions (e.g. `config.fixture_path=` → `config.fixture_paths=`, `update_attributes` → `update` before its removal), migrate the call site directly — do not wrap it in `NextRails.next?`. See `references/code-patterns.md` "When NOT to Branch: Deprecations".
 
 ---
 

--- a/dual-boot/SKILL.md
+++ b/dual-boot/SKILL.md
@@ -31,7 +31,7 @@ This skill helps you:
 
 ## CRITICAL: Always Use `NextRails.next?` — Never Use Feature Detection
 
-When writing code that must work with both the current and target versions, **always use `NextRails.next?`** from the `next_rails` gem. Never use `respond_to?`, `defined?`, `const_defined?`, or any other feature-detection pattern for version branching.
+When code would break on one version and needs a different implementation on the other, **always use `NextRails.next?`** from the `next_rails` gem to branch — never feature detection. Do not use `respond_to?`, `defined?`, `const_defined?`, or any other feature-detection pattern for version branching.
 
 **Why feature detection is problematic:**
 - **Hard to understand:** readers must know which version introduced a method or constant to grasp the intent
@@ -50,26 +50,25 @@ Reach for `NextRails.next?` only when the old and new APIs are genuinely **two-s
 
 ❌ **WRONG — Do NOT use feature detection (`respond_to?`, `defined?`, etc.):**
 ```ruby
-if Project.respond_to?(:ignored_columns=)
-  self.ignored_columns += [:category]
-else
-  ignore_columns :category
-end
+test_request =
+  if ActionController::TestRequest.respond_to?(:create)
+    ActionController::TestRequest.create
+  else
+    ActionController::TestRequest.new
+  end
 ```
 
 ✅ **CORRECT — Use `NextRails.next?`:**
 ```ruby
-# app/models/project.rb
-class Project < ActiveRecord::Base
+test_request =
   if NextRails.next?
-    self.ignored_columns += [:category]
+    ActionController::TestRequest.create
   else
-    ignore_columns :category
+    ActionController::TestRequest.new
   end
-end
 ```
 
-This is a genuine two-sided case (Rails 4.2 → 5.0): on 4.2 the app uses the [`ignorable`](https://github.com/nthj/ignorable) gem's `ignore_columns` class method. Rails 5.0 introduced native `ignored_columns=` with different syntax, and once the gem is dropped on the 5.0 side, `ignore_columns` raises `NoMethodError`. `ignored_columns=` raises `NoMethodError` on 4.2 where it doesn't yet exist.
+This is a genuine two-sided case (Rails 4.2 → 5.0). On 4.2, [`ActionController::TestRequest.new`](https://github.com/rails/rails/blob/11f2bdf75a888682b34df0f9be03b94f54fc6796/actionpack/lib/action_controller/test_case.rb#L201) takes an optional `env`; on 5.0 `new` [requires two non-optional arguments](https://github.com/rails/rails/blob/c4d3e202e10ae627b3b9c34498afb45450652421/actionpack/lib/action_controller/test_case.rb#L48) so the 4.2 call fails. Rails 5.0 introduces `TestRequest.create`, which does not exist on 4.2 — so each side raises on the other.
 
 Put the next-version branch on top so cleanup is mechanical: after the upgrade, keep the `if` body and drop the `else`. See `references/code-patterns.md` for more examples.
 

--- a/dual-boot/SKILL.md
+++ b/dual-boot/SKILL.md
@@ -46,29 +46,34 @@ When writing code that must work with both the current and target versions, **al
 
 ### Pattern
 
+The right time for a conditional is when the old code actually **breaks** on the next version (removed constant, removed method, incompatible signature) — not when it merely emits a deprecation warning. Deprecations should be fixed by replacing the code outright, since the new form works on both versions.
+
+Example: `ActionDispatch::Http::ParameterFilter` was removed in Rails 6.1 (replaced by `ActiveSupport::ParameterFilter`). Referencing the old constant under 6.1 raises `NameError`, so a conditional is required during 6.0 → 6.1 dual-boot.
+
 ❌ **WRONG — Do NOT use `respond_to?`:**
 ```ruby
-if config.respond_to?(:fixture_paths=)
-  config.fixture_paths = ["#{::Rails.root}/spec/fixtures"]
+if defined?(ActiveSupport::ParameterFilter)
+  filter = ActiveSupport::ParameterFilter.new([:password])
 else
-  config.fixture_path = "#{::Rails.root}/spec/fixtures"
+  filter = ActionDispatch::Http::ParameterFilter.new([:password])
 end
 ```
 
 ✅ **CORRECT — Use `NextRails.next?`:**
 ```ruby
 if NextRails.next?
-  config.fixture_paths = ["#{::Rails.root}/spec/fixtures"]
+  filter = ActiveSupport::ParameterFilter.new([:password])
 else
-  config.fixture_path = "#{::Rails.root}/spec/fixtures"
+  filter = ActionDispatch::Http::ParameterFilter.new([:password])
 end
 ```
 
 ### When to Apply
 
 Use `NextRails.next?` branching for:
-- **Configuration changes** (e.g., `fixture_path` → `fixture_paths`)
-- **API changes** (e.g., method renames, changed signatures, removed methods)
+- **Removed constants or methods** (e.g., `ActionDispatch::Http::ParameterFilter` removed in Rails 6.1, `update_attributes` removed in Rails 6.1)
+- **Incompatible signature or return-type changes** (e.g., a method that now returns a different object type)
+- **Deprecations are NOT a reason to branch** — if the new API works on both versions, just replace the call site. Reserve conditionals for code that otherwise breaks under the next version.
 - **Gem version differences** (e.g., different gem APIs across dependency versions)
 - **Initializer changes** (e.g., different middleware, different default settings)
 - **Ruby version differences** (e.g., syntax changes, stdlib removals)

--- a/dual-boot/SKILL.md
+++ b/dual-boot/SKILL.md
@@ -29,15 +29,15 @@ This skill helps you:
 
 ---
 
-## CRITICAL: Always Use `NextRails.next?` — Never Use `respond_to?`
+## CRITICAL: Always Use `NextRails.next?` — Never Use Feature Detection
 
-When writing code that must work with both the current and target versions, **always use `NextRails.next?`** from the `next_rails` gem. Never use `respond_to?` or other feature-detection patterns for version branching.
+When writing code that must work with both the current and target versions, **always use `NextRails.next?`** from the `next_rails` gem. Never use `respond_to?`, `defined?`, `const_defined?`, or any other feature-detection pattern for version branching.
 
-**Why `respond_to?` is problematic:**
-- **Hard to understand:** readers must know which version introduced a method to grasp the intent
-- **Hard to maintain:** `respond_to?` checks pile up and become impossible to clean up because their purpose is lost
-- **Fragile:** may give wrong results if gems monkey-patch methods in or out
-- **Obscures intent:** the code says "does this method exist?" when it means "are we on the next Rails version?"
+**Why feature detection is problematic:**
+- **Hard to understand:** readers must know which version introduced a method or constant to grasp the intent
+- **Hard to maintain:** `respond_to?` / `defined?` checks pile up and become impossible to clean up because their purpose is lost
+- **Fragile:** may give wrong results if gems monkey-patch methods or constants in or out
+- **Obscures intent:** the code says "does this exist?" when it means "are we on the next Rails version?"
 
 **Why `NextRails.next?` is better:**
 - **Explicit and readable:** anyone reading the code immediately understands "this branch is for the next version"
@@ -50,7 +50,7 @@ The right time for a conditional is when the old code actually **breaks** on the
 
 Example: `ActionDispatch::Http::ParameterFilter` was removed in Rails 6.1 (replaced by `ActiveSupport::ParameterFilter`). Referencing the old constant under 6.1 raises `NameError`, so a conditional is required during 6.0 → 6.1 dual-boot.
 
-❌ **WRONG — Do NOT use `respond_to?`:**
+❌ **WRONG — Do NOT use feature detection (`defined?`, `respond_to?`, etc.):**
 ```ruby
 if defined?(ActiveSupport::ParameterFilter)
   filter = ActiveSupport::ParameterFilter.new([:password])
@@ -73,10 +73,11 @@ end
 Use `NextRails.next?` branching for:
 - **Removed constants or methods** (e.g., `ActionDispatch::Http::ParameterFilter` removed in Rails 6.1, `update_attributes` removed in Rails 6.1)
 - **Incompatible signature or return-type changes** (e.g., a method that now returns a different object type)
-- **Deprecations are NOT a reason to branch** — if the new API works on both versions, just replace the call site. Reserve conditionals for code that otherwise breaks under the next version.
-- **Gem version differences** (e.g., different gem APIs across dependency versions)
-- **Initializer changes** (e.g., different middleware, different default settings)
+- **Gem version differences where the old API is gone in the new version** (not just renamed-with-alias)
+- **Initializer changes that break on one side** (e.g., middleware removed from defaults, config key that raises on the other version)
 - **Ruby version differences** (e.g., syntax changes, stdlib removals)
+
+**Not a reason to branch:** deprecation warnings. If the new API works on both versions, migrate the call site directly — do not wrap it in `NextRails.next?`. See `references/code-patterns.md` "When NOT to Branch: Deprecations".
 
 ---
 

--- a/dual-boot/examples/basic-setup.md
+++ b/dual-boot/examples/basic-setup.md
@@ -26,6 +26,8 @@ next_rails --init
 
 ### 3. Configure Gemfile
 
+If your 4.2 app already depends on a gem that needs dropping on the 5.0 side (the `ignorable` gem in this example), move it from the Gemfile root into the `else` branch so it's installed only for Rails 4.2.
+
 ```ruby
 # Gemfile
 

--- a/dual-boot/examples/basic-setup.md
+++ b/dual-boot/examples/basic-setup.md
@@ -26,8 +26,6 @@ next_rails --init
 
 ### 3. Configure Gemfile
 
-If your 4.2 app already depends on a gem that needs dropping on the 5.0 side (the `ignorable` gem in this example), move it from the Gemfile root into the `else` branch so it's installed only for Rails 4.2.
-
 ```ruby
 # Gemfile
 
@@ -41,7 +39,6 @@ if next?
   gem 'rails', '~> 5.0.0'
 else
   gem 'rails', '~> 4.2.0'
-  gem 'ignorable' # used for `ignore_columns` on 4.2; dropped on 5.0
 end
 
 gem 'next_rails'
@@ -72,17 +69,16 @@ BUNDLE_GEMFILE=Gemfile.next bundle exec rspec
 
 ### 6. Fix a Breaking Change
 
-Rails 5.0 introduced a native `ignored_columns=` setter, replacing the `ignorable` gem's `ignore_columns` class method. With the gem dropped on the 5.0 side, `ignore_columns` raises `NoMethodError` there; `ignored_columns=` raises `NoMethodError` on 4.2 where it doesn't yet exist. A conditional is required:
+On Rails 4.2, `ActionController::TestRequest.new` takes an optional `env`. On 5.0, `new` requires two non-optional arguments (so the 4.2 call raises `ArgumentError`), and 5.0 introduces `TestRequest.create` — which doesn't exist on 4.2 (`NoMethodError`). Each side raises on the other. A conditional is required:
 
 ```ruby
-# app/models/project.rb
-class Project < ActiveRecord::Base
+# spec/requests/projects_spec.rb
+test_request =
   if NextRails.next?
-    self.ignored_columns += [:category]
+    ActionController::TestRequest.create
   else
-    ignore_columns :category
+    ActionController::TestRequest.new
   end
-end
 ```
 
 ### 7. Verify Both Pass
@@ -95,7 +91,7 @@ BUNDLE_GEMFILE=Gemfile.next bundle exec rspec  # Next: green
 ### 8. Commit
 
 ```bash
-git add Gemfile Gemfile.next Gemfile.next.lock app/models/project.rb
+git add Gemfile Gemfile.next Gemfile.next.lock spec/requests/projects_spec.rb
 git commit -m "Set up dual-boot for Rails 4.2 → 5.0 upgrade"
 ```
 
@@ -106,19 +102,16 @@ git commit -m "Set up dual-boot for Rails 4.2 → 5.0 upgrade"
 Once you're fully on Rails 5.0, clean up:
 
 ```ruby
-# app/models/project.rb — BEFORE cleanup
-class Project < ActiveRecord::Base
+# spec/requests/projects_spec.rb — BEFORE cleanup
+test_request =
   if NextRails.next?
-    self.ignored_columns += [:category]
+    ActionController::TestRequest.create
   else
-    ignore_columns :category
+    ActionController::TestRequest.new
   end
-end
 
-# app/models/project.rb — AFTER cleanup
-class Project < ActiveRecord::Base
-  self.ignored_columns += [:category]
-end
+# spec/requests/projects_spec.rb — AFTER cleanup
+test_request = ActionController::TestRequest.create
 ```
 
 See `workflows/cleanup-workflow.md` for the full cleanup process.

--- a/dual-boot/examples/basic-setup.md
+++ b/dual-boot/examples/basic-setup.md
@@ -78,6 +78,8 @@ if NextRails.next?
 else
   filter = ActionDispatch::Http::ParameterFilter.new([:password, :token])
 end
+
+filter.filter(params)
 ```
 
 Note: a pure deprecation warning (old API still works under next) is **not** a reason to branch — replace the call site directly. Reserve `NextRails.next?` for code that would otherwise fail to load or run.
@@ -110,8 +112,11 @@ else
   filter = ActionDispatch::Http::ParameterFilter.new([:password, :token])
 end
 
+filter.filter(params)
+
 # app/services/log_sanitizer.rb — AFTER cleanup
 filter = ActiveSupport::ParameterFilter.new([:password, :token])
+filter.filter(params)
 ```
 
 See `workflows/cleanup-workflow.md` for the full cleanup process.

--- a/dual-boot/examples/basic-setup.md
+++ b/dual-boot/examples/basic-setup.md
@@ -4,7 +4,7 @@ This example walks through a Rails version upgrade. The same approach applies wh
 
 ## Scenario
 
-You have a Rails 6.0 application and want to upgrade to Rails 6.1. You want to set up dual-boot to test both versions during the transition.
+You have a Rails 4.2 application and want to upgrade to Rails 5.0. You want to set up dual-boot to test both versions during the transition.
 
 ---
 
@@ -36,9 +36,10 @@ def next?
 end
 
 if next?
-  gem 'rails', '~> 6.1.0'
+  gem 'rails', '~> 5.0.0'
 else
-  gem 'rails', '~> 6.0.0'
+  gem 'rails', '~> 4.2.0'
+  gem 'ignorable' # used for `ignore_columns` on 4.2; dropped on 5.0
 end
 
 gem 'next_rails'
@@ -58,31 +59,29 @@ BUNDLE_GEMFILE=Gemfile.next bundle install
 ### 5. Run Tests Against Both
 
 ```bash
-# Current version (6.0)
+# Current version (4.2)
 bundle exec rspec
 # => All green
 
-# Next version (6.1)
+# Next version (5.0)
 BUNDLE_GEMFILE=Gemfile.next bundle exec rspec
 # => Some failures — fix using NextRails.next? branching
 ```
 
 ### 6. Fix a Breaking Change
 
-Rails 6.1 removed `ActionDispatch::Http::ParameterFilter` — referencing it under 6.1 raises `NameError: uninitialized constant`. The replacement `ActiveSupport::ParameterFilter` does not exist on 6.0, so a conditional is required:
+Rails 5.0 introduced a native `ignored_columns=` setter, replacing the `ignorable` gem's `ignore_columns` class method. With the gem dropped on the 5.0 side, `ignore_columns` raises `NoMethodError` there; `ignored_columns=` raises `NoMethodError` on 4.2 where it doesn't yet exist. A conditional is required:
 
 ```ruby
-# app/services/log_sanitizer.rb
-if NextRails.next?
-  filter = ActiveSupport::ParameterFilter.new([:password, :token])
-else
-  filter = ActionDispatch::Http::ParameterFilter.new([:password, :token])
+# app/models/project.rb
+class Project < ActiveRecord::Base
+  if NextRails.next?
+    self.ignored_columns += [:category]
+  else
+    ignore_columns :category
+  end
 end
-
-filter.filter(params)
 ```
-
-Note: a pure deprecation warning (old API still works under next) is **not** a reason to branch — replace the call site directly. Reserve `NextRails.next?` for code that would otherwise fail to load or run.
 
 ### 7. Verify Both Pass
 
@@ -94,29 +93,30 @@ BUNDLE_GEMFILE=Gemfile.next bundle exec rspec  # Next: green
 ### 8. Commit
 
 ```bash
-git add Gemfile Gemfile.next Gemfile.next.lock app/services/log_sanitizer.rb
-git commit -m "Set up dual-boot for Rails 6.0 → 6.1 upgrade"
+git add Gemfile Gemfile.next Gemfile.next.lock app/models/project.rb
+git commit -m "Set up dual-boot for Rails 4.2 → 5.0 upgrade"
 ```
 
 ---
 
 ## After Upgrade Is Complete
 
-Once you're fully on Rails 6.1, clean up:
+Once you're fully on Rails 5.0, clean up:
 
 ```ruby
-# app/services/log_sanitizer.rb — BEFORE cleanup
-if NextRails.next?
-  filter = ActiveSupport::ParameterFilter.new([:password, :token])
-else
-  filter = ActionDispatch::Http::ParameterFilter.new([:password, :token])
+# app/models/project.rb — BEFORE cleanup
+class Project < ActiveRecord::Base
+  if NextRails.next?
+    self.ignored_columns += [:category]
+  else
+    ignore_columns :category
+  end
 end
 
-filter.filter(params)
-
-# app/services/log_sanitizer.rb — AFTER cleanup
-filter = ActiveSupport::ParameterFilter.new([:password, :token])
-filter.filter(params)
+# app/models/project.rb — AFTER cleanup
+class Project < ActiveRecord::Base
+  self.ignored_columns += [:category]
+end
 ```
 
 See `workflows/cleanup-workflow.md` for the full cleanup process.

--- a/dual-boot/examples/basic-setup.md
+++ b/dual-boot/examples/basic-setup.md
@@ -4,7 +4,7 @@ This example walks through a Rails version upgrade. The same approach applies wh
 
 ## Scenario
 
-You have a Rails 7.0 application and want to upgrade to Rails 7.1. You want to set up dual-boot to test both versions during the transition.
+You have a Rails 6.0 application and want to upgrade to Rails 6.1. You want to set up dual-boot to test both versions during the transition.
 
 ---
 
@@ -36,9 +36,9 @@ def next?
 end
 
 if next?
-  gem 'rails', '~> 7.1.0'
+  gem 'rails', '~> 6.1.0'
 else
-  gem 'rails', '~> 7.0.0'
+  gem 'rails', '~> 6.0.0'
 end
 
 gem 'next_rails'
@@ -58,27 +58,29 @@ BUNDLE_GEMFILE=Gemfile.next bundle install
 ### 5. Run Tests Against Both
 
 ```bash
-# Current version (7.0)
+# Current version (6.0)
 bundle exec rspec
 # => All green
 
-# Next version (7.1)
+# Next version (6.1)
 BUNDLE_GEMFILE=Gemfile.next bundle exec rspec
 # => Some failures — fix using NextRails.next? branching
 ```
 
 ### 6. Fix a Breaking Change
 
-Rails 7.1 changed `fixture_path` to `fixture_paths`. Fix it:
+Rails 6.1 removed `ActionDispatch::Http::ParameterFilter` — referencing it under 6.1 raises `NameError: uninitialized constant`. The replacement `ActiveSupport::ParameterFilter` does not exist on 6.0, so a conditional is required:
 
 ```ruby
-# spec/rails_helper.rb
+# app/services/log_sanitizer.rb
 if NextRails.next?
-  config.fixture_paths = ["#{::Rails.root}/spec/fixtures"]
+  filter = ActiveSupport::ParameterFilter.new([:password, :token])
 else
-  config.fixture_path = "#{::Rails.root}/spec/fixtures"
+  filter = ActionDispatch::Http::ParameterFilter.new([:password, :token])
 end
 ```
+
+Note: a pure deprecation warning (old API still works under next) is **not** a reason to branch — replace the call site directly. Reserve `NextRails.next?` for code that would otherwise fail to load or run.
 
 ### 7. Verify Both Pass
 
@@ -90,26 +92,26 @@ BUNDLE_GEMFILE=Gemfile.next bundle exec rspec  # Next: green
 ### 8. Commit
 
 ```bash
-git add Gemfile Gemfile.next Gemfile.next.lock spec/rails_helper.rb
-git commit -m "Set up dual-boot for Rails 7.0 → 7.1 upgrade"
+git add Gemfile Gemfile.next Gemfile.next.lock app/services/log_sanitizer.rb
+git commit -m "Set up dual-boot for Rails 6.0 → 6.1 upgrade"
 ```
 
 ---
 
 ## After Upgrade Is Complete
 
-Once you're fully on Rails 7.1, clean up:
+Once you're fully on Rails 6.1, clean up:
 
 ```ruby
-# spec/rails_helper.rb — BEFORE cleanup
+# app/services/log_sanitizer.rb — BEFORE cleanup
 if NextRails.next?
-  config.fixture_paths = ["#{::Rails.root}/spec/fixtures"]
+  filter = ActiveSupport::ParameterFilter.new([:password, :token])
 else
-  config.fixture_path = "#{::Rails.root}/spec/fixtures"
+  filter = ActionDispatch::Http::ParameterFilter.new([:password, :token])
 end
 
-# spec/rails_helper.rb — AFTER cleanup
-config.fixture_paths = ["#{::Rails.root}/spec/fixtures"]
+# app/services/log_sanitizer.rb — AFTER cleanup
+filter = ActiveSupport::ParameterFilter.new([:password, :token])
 ```
 
 See `workflows/cleanup-workflow.md` for the full cleanup process.

--- a/dual-boot/references/code-patterns.md
+++ b/dual-boot/references/code-patterns.md
@@ -8,20 +8,20 @@ Use `NextRails.next?` anywhere your application code must behave differently bet
 
 ---
 
-## Rails API Removals
+## Rails API Changes Requiring a Conditional
 
-### `ActionDispatch::Http::ParameterFilter` removed in Rails 6.1
+### `ignorable` gem → native `ignored_columns=` (Rails 4.2 → 5.0)
 
-Under Rails 6.1 the old constant raises `NameError`; under Rails 6.0 the new one does not yet exist. A conditional is required during dual-boot.
+An app using the [`ignorable`](https://github.com/nthj/ignorable) gem to ignore columns on Rails 4.2 hits a genuine two-sided case when upgrading to 5.0, which introduced a native `ignored_columns=` with different syntax. If the gem is dropped on the 5.0 side (since Rails now has the feature), `ignore_columns :category` raises `NoMethodError` there; `self.ignored_columns += [:category]` raises `NoMethodError` on 4.2 where the setter doesn't exist yet.
 
 ```ruby
-# app/services/log_sanitizer.rb
-if NextRails.next?
-  filter = ActiveSupport::ParameterFilter.new([:password, :token])
-  filter.filter(params)
-else
-  filter = ActionDispatch::Http::ParameterFilter.new([:password, :token])
-  filter.filter(params)
+# app/models/project.rb
+class Project < ActiveRecord::Base
+  if NextRails.next?
+    self.ignored_columns += [:category]
+  else
+    ignore_columns :category
+  end
 end
 ```
 
@@ -49,7 +49,7 @@ end
 config.fixture_paths = ["#{::Rails.root}/spec/fixtures"]
 ```
 
-Same rule applies to `serialize :preferences, coder: JSON` vs. the older positional form, `update` vs. `update_attributes` (prior to 6.1 removal), and most Rails API evolution: if both versions accept the new form, migrate call sites directly and skip the conditional.
+Same rule applies to `serialize :preferences, coder: JSON` vs. the older positional form, `update` vs. `update_attributes` (prior to the 6.1 removal), and most Rails API evolution: if both versions accept the new form, migrate call sites directly and skip the conditional.
 
 ---
 

--- a/dual-boot/references/code-patterns.md
+++ b/dual-boot/references/code-patterns.md
@@ -6,6 +6,8 @@ Use `NextRails.next?` anywhere your application code must behave differently bet
 
 **Only branch when the old code actually breaks on the next version.** A deprecation warning is not a reason for a conditional — if the new API works on both, replace the call site directly and let the deprecation disappear on its own. Reserve `NextRails.next?` for removed constants, removed methods, or incompatible signature/return-type changes that would raise an error otherwise.
 
+The version numbers in the example below are from a Rails 4.2 → 5.0 upgrade, but the pattern applies any time a gem-provided API is replaced by a native Rails API with different syntax (or vice versa) — the same shape works for any adjacent-version boundary where dropping the gem on one side makes the call unavailable.
+
 ---
 
 ## Rails API Changes Requiring a Conditional
@@ -71,21 +73,6 @@ end
 if NextRails.next?
   # Ruby 3.2+ uses a different default for Regexp timeout
   Regexp.timeout = 5
-end
-```
-
----
-
-## Core Dependency Changes
-
-### Sidekiq API change (6.x → 7.x)
-
-```ruby
-# config/initializers/sidekiq.rb
-if NextRails.next?
-  Sidekiq.default_job_options = { 'retry' => 3 }
-else
-  Sidekiq.default_worker_options = { 'retry' => 3 }
 end
 ```
 

--- a/dual-boot/references/code-patterns.md
+++ b/dual-boot/references/code-patterns.md
@@ -6,25 +6,23 @@ Use `NextRails.next?` anywhere your application code must behave differently bet
 
 **Only branch when the old code actually breaks on the next version.** A deprecation warning is not a reason for a conditional — if the new API works on both, replace the call site directly and let the deprecation disappear on its own. Reserve `NextRails.next?` for removed constants, removed methods, or incompatible signature/return-type changes that would raise an error otherwise.
 
-The version numbers in the example below are from a Rails 4.2 → 5.0 upgrade, but the pattern applies any time a gem-provided API is replaced by a native Rails API with different syntax (or vice versa) — the same shape works for any adjacent-version boundary where dropping the gem on one side makes the call unavailable.
+The version numbers in the example below are from a Rails 4.2 → 5.0 upgrade, but the pattern applies any time a method's signature or availability changes incompatibly across versions — the same shape works for any adjacent-version boundary where each side raises on the other's call.
 
 ---
 
 ## Rails API Changes Requiring a Conditional
 
-### `ignorable` gem → native `ignored_columns=` (Rails 4.2 → 5.0)
+### `ActionController::TestRequest.new` → `.create` (Rails 4.2 → 5.0)
 
-An app using the [`ignorable`](https://github.com/nthj/ignorable) gem to ignore columns on Rails 4.2 hits a genuine two-sided case when upgrading to 5.0, which introduced a native `ignored_columns=` with different syntax. If the gem is dropped on the 5.0 side (since Rails now has the feature), `ignore_columns :category` raises `NoMethodError` there; `self.ignored_columns += [:category]` raises `NoMethodError` on 4.2 where the setter doesn't exist yet.
+On Rails 4.2, [`ActionController::TestRequest.new`](https://github.com/rails/rails/blob/11f2bdf75a888682b34df0f9be03b94f54fc6796/actionpack/lib/action_controller/test_case.rb#L201) takes an optional `env` argument. On Rails 5.0, `new` [requires two non-optional arguments](https://github.com/rails/rails/blob/c4d3e202e10ae627b3b9c34498afb45450652421/actionpack/lib/action_controller/test_case.rb#L48), so the 4.2-style call raises `ArgumentError`. Rails 5.0 introduced `TestRequest.create` to hide that complexity — but `.create` does not exist on 4.2 (`NoMethodError`). Each side raises on the other's call.
 
 ```ruby
-# app/models/project.rb
-class Project < ActiveRecord::Base
+test_request =
   if NextRails.next?
-    self.ignored_columns += [:category]
+    ActionController::TestRequest.create
   else
-    ignore_columns :category
+    ActionController::TestRequest.new
   end
-end
 ```
 
 ---

--- a/dual-boot/references/code-patterns.md
+++ b/dual-boot/references/code-patterns.md
@@ -18,18 +18,10 @@ Under Rails 6.1 the old constant raises `NameError`; under Rails 6.0 the new one
 # app/services/log_sanitizer.rb
 if NextRails.next?
   filter = ActiveSupport::ParameterFilter.new([:password, :token])
+  filter.filter(params)
 else
   filter = ActionDispatch::Http::ParameterFilter.new([:password, :token])
-end
-```
-
-### config/initializers/session_store.rb
-
-```ruby
-if NextRails.next?
-  Rails.application.config.session_store :cookie_store, key: '_myapp_session'
-else
-  Rails.application.config.session_store :cookie_store, key: '_myapp_session', secure: Rails.env.production?
+  filter.filter(params)
 end
 ```
 

--- a/dual-boot/references/code-patterns.md
+++ b/dual-boot/references/code-patterns.md
@@ -4,17 +4,22 @@
 
 Use `NextRails.next?` anywhere your application code must behave differently between the current and next dependency sets. This is the **only** acceptable way to branch on version — whether you are upgrading Rails, Ruby, or another core dependency.
 
+**Only branch when the old code actually breaks on the next version.** A deprecation warning is not a reason for a conditional — if the new API works on both, replace the call site directly and let the deprecation disappear on its own. Reserve `NextRails.next?` for removed constants, removed methods, or incompatible signature/return-type changes that would raise an error otherwise.
+
 ---
 
-## Rails Configuration Changes
+## Rails API Removals
 
-### spec/rails_helper.rb — `fixture_path` → `fixture_paths`
+### `ActionDispatch::Http::ParameterFilter` removed in Rails 6.1
+
+Under Rails 6.1 the old constant raises `NameError`; under Rails 6.0 the new one does not yet exist. A conditional is required during dual-boot.
 
 ```ruby
+# app/services/log_sanitizer.rb
 if NextRails.next?
-  config.fixture_paths = ["#{::Rails.root}/spec/fixtures"]
+  filter = ActiveSupport::ParameterFilter.new([:password, :token])
 else
-  config.fixture_path = "#{::Rails.root}/spec/fixtures"
+  filter = ActionDispatch::Http::ParameterFilter.new([:password, :token])
 end
 ```
 
@@ -30,18 +35,29 @@ end
 
 ---
 
-## Rails Model Changes
+## When NOT to Branch: Deprecations
 
-### Serialization API change
+If the **new** API exists on the current version too, there is no breaking change — just replace the call site. Wrapping a deprecation in `NextRails.next?` adds dead branches you'll have to clean up for no benefit.
+
+❌ **WRONG — `fixture_path` → `fixture_paths` (deprecation only):**
 
 ```ruby
-# app/models/user.rb
+# Both config.fixture_path= and config.fixture_paths= work on Rails 7.0 and 7.1.
+# 7.1 only emits a deprecation warning for the old setter.
 if NextRails.next?
-  serialize :preferences, coder: JSON
+  config.fixture_paths = ["#{::Rails.root}/spec/fixtures"]
 else
-  serialize :preferences, JSON
+  config.fixture_path = "#{::Rails.root}/spec/fixtures"
 end
 ```
+
+✅ **CORRECT — just use the new API everywhere:**
+
+```ruby
+config.fixture_paths = ["#{::Rails.root}/spec/fixtures"]
+```
+
+Same rule applies to `serialize :preferences, coder: JSON` vs. the older positional form, `update` vs. `update_attributes` (prior to 6.1 removal), and most Rails API evolution: if both versions accept the new form, migrate call sites directly and skip the conditional.
 
 ---
 

--- a/dual-boot/workflows/cleanup-workflow.md
+++ b/dual-boot/workflows/cleanup-workflow.md
@@ -28,16 +28,20 @@ For each file found in Step 1, keep only the `NextRails.next?` (true) branch and
 
 ### Before:
 ```ruby
-if NextRails.next?
-  config.fixture_paths = ["#{::Rails.root}/spec/fixtures"]
-else
-  config.fixture_path = "#{::Rails.root}/spec/fixtures"
+class Project < ActiveRecord::Base
+  if NextRails.next?
+    self.ignored_columns += [:category]
+  else
+    ignore_columns :category
+  end
 end
 ```
 
 ### After:
 ```ruby
-config.fixture_paths = ["#{::Rails.root}/spec/fixtures"]
+class Project < ActiveRecord::Base
+  self.ignored_columns += [:category]
+end
 ```
 
 ---

--- a/dual-boot/workflows/cleanup-workflow.md
+++ b/dual-boot/workflows/cleanup-workflow.md
@@ -28,20 +28,17 @@ For each file found in Step 1, keep only the `NextRails.next?` (true) branch and
 
 ### Before:
 ```ruby
-class Project < ActiveRecord::Base
+test_request =
   if NextRails.next?
-    self.ignored_columns += [:category]
+    ActionController::TestRequest.create
   else
-    ignore_columns :category
+    ActionController::TestRequest.new
   end
-end
 ```
 
 ### After:
 ```ruby
-class Project < ActiveRecord::Base
-  self.ignored_columns += [:category]
-end
+test_request = ActionController::TestRequest.create
 ```
 
 ---


### PR DESCRIPTION
Closes #2.

## Problem

@arielj pointed out that the two dual-boot examples in `SKILL.md`, `examples/basic-setup.md`, and `references/code-patterns.md` — `fixture_path` → `fixture_paths` and `serialize :preferences, JSON` → `serialize :preferences, coder: JSON` — are **backwards-compatible deprecations**, not breaking changes. The new API works on both Rails versions, so wrapping them in `NextRails.next?` is unnecessary and teaches the wrong lesson: that deprecation warnings require a conditional. They don't — deprecations should be migrated directly.

## Fix

Replace the bad examples with a genuine breaking change: the [`ignorable`](https://github.com/nthj/ignorable) gem's `ignore_columns` → native `ignored_columns=` at **Rails 4.2 → 5.0**. This is genuinely two-sided:

- On Rails 4.2 the app uses the `ignorable` gem's `ignore_columns` class method.
- Rails 5.0 introduced native `ignored_columns=` with different syntax.
- Once the gem is dropped on the 5.0 side, `ignore_columns` raises `NoMethodError` there.
- `ignored_columns=` raises `NoMethodError` on 4.2 where the setter doesn't exist yet.

Referencing either API without a conditional raises on one side or the other, so `NextRails.next?` is actually required:

```ruby
# app/models/project.rb
class Project < ActiveRecord::Base
  if NextRails.next?
    self.ignored_columns += [:category]
  else
    ignore_columns :category
  end
end
```

Also added a new **"When NOT to Branch: Deprecations"** section in `references/code-patterns.md` using `fixture_path` → `fixture_paths` as the counter-example, so readers learn that deprecations are unconditional migrations — not `NextRails.next?` conditionals.

## Why Rails 4.2 → 5.0?

An earlier revision of this PR used `ActionDispatch::Http::ParameterFilter` (removed in 6.1) → `ActiveSupport::ParameterFilter`, framed as a 6.0 → 6.1 case. Review found that example wasn't actually two-sided: `ActiveSupport::ParameterFilter` shipped in Rails **6.0**, not 6.1 (verified against `activesupport/CHANGELOG.md` at the `v6.0.0` tag), so the replacement already exists on the current side and the correct fix is an unconditional migration — the exact anti-pattern this PR is arguing against.

After verifying several candidates against primary sources, `ignorable` → `ignored_columns=` at 4.2 → 5.0 is the cleanest adjacent-minor case where both directions genuinely raise. The version numbers are older than is ideal, but the pattern ("third-party gem replaced by a native Rails API with different syntax") is timeless and the teaching is what matters.

## Follow-ups included in this PR

- **Standardize on `NextRails.next?`.** The gem also exposes `NextRails.current?`, and `CLAUDE.md` previously said "either is fine." The rest of the skill uses `.next?` exclusively, so the "either" clause invited drift. Dropped `.current?` from the supported polarity — one polarity means readers never have to mentally flip the check across files.
- **Broadened the "no feature detection" rule.** Now calls out `defined?` and `const_defined?` alongside `respond_to?`, since feature detection for removed *constants* (not just methods) is the same anti-pattern.
- **New invariant #7**: only branch for genuine breaking changes (removed constants, removed methods, incompatible signatures). Captures the teaching added by this PR so future edits don't re-introduce deprecation-wrapping examples.


## Files touched

- `dual-boot/SKILL.md` — Pattern example swapped, feature-detection rule broadened, "When to Apply" polish
- `dual-boot/examples/basic-setup.md` — scenario shifted to Rails 4.2 → 5.0, Step 6 rewritten with `ignored_columns`
- `dual-boot/references/code-patterns.md` — `ignored_columns` example replaces `fixture_path`; new "When NOT to Branch: Deprecations" section; removed the `session_store` subsection (dead branching)
- `dual-boot/workflows/cleanup-workflow.md` — Step 2 Before/After now uses `ignored_columns`
- `dual-boot/CHANGELOG.md` — v1.1 entry
- `README.md` — Key Principle example swapped, feature-detection broadened, deprecation rule added
- `CLAUDE.md` — `.next?` standardization, invariant #7
