### PR TITLE
Reframe NextRails.next? teaching: Gemfile primacy + three-tier pattern

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,13 @@ contradict any of them, stop and surface the conflict instead of shipping.
    incompatible signatures. If the new API works on both versions (i.e. the old one
    merely emits a deprecation warning), migrate the call site directly instead of
    wrapping it in `NextRails.next?`. See `dual-boot/SKILL.md` "Pattern" section.
+8. **Prefer a single backport/forwardport shim over scattered conditionals when the
+   version gap spans an application layer** (all controllers, all mailers, all models
+   with the same concern) **or affects roughly 20+ call sites**. A shim in one file
+   (`config/initializers/*.rb`, `test_helper.rb`, `spec_helper.rb`) keeps call sites
+   identical across both versions and collapses to a single-file delete at cleanup.
+   `NextRails.next?` call-site conditionals are fine for smaller gaps. See
+   `dual-boot/references/code-patterns.md` "Three-Tier Approach".
 
 ---
 

--- a/dual-boot/SKILL.md
+++ b/dual-boot/SKILL.md
@@ -142,7 +142,7 @@ See `workflows/setup-workflow.md` for the complete step-by-step process.
 3. Add `next_rails` gem at the Gemfile root and run `bundle install`
 4. Run `next_rails --init` (only if `Gemfile.next` does NOT exist)
 5. Configure `DeprecationTracker` (ask upfront whether CI runs tests in parallel)
-6. Capture the deprecation inventory: `DEPRECATION_TRACKER=save bundle exec rspec`
+6. Capture the deprecation inventory: `DEPRECATION_TRACKER=save bundle exec rspec` (substitute the project's test command: `bin/rails test`, `bin/test`, `bundle exec parallel_rspec spec/`, etc.)
 7. Fix current-side deprecations unconditionally (Tier 1, no `NextRails.next?`)
 
 *Phase 2, dual-boot (the version hop):*

--- a/dual-boot/SKILL.md
+++ b/dual-boot/SKILL.md
@@ -46,7 +46,29 @@ When code would break on one version and needs a different implementation on the
 
 ### Pattern
 
-Reach for `NextRails.next?` only when the old and new APIs are genuinely **two-sided** — the old one raises on the next version and the new one doesn't exist on the current version. A plain deprecation warning is *not* a reason to branch: if the new API works on both sides, migrate the call site directly.
+Every dual-boot has exactly one conditional that is always required: the Gemfile version pin. That is the canonical use of `next?`. App-code `NextRails.next?` is the exception, reserved for genuine two-sided breakage that cannot be resolved by migrating to a common API.
+
+**The canonical conditional, the Gemfile version pin:**
+```ruby
+# Gemfile
+if next?
+  gem 'rails', '~> 7.1.0'
+else
+  gem 'rails', '~> 7.0.0'
+end
+```
+
+The two pins genuinely fail resolution on opposite sides, so this conditional is required for bundler to resolve at all. Most dual-boots need nothing more than this plus a handful of gem-version pins for dependencies tied to the Rails version.
+
+**Three-tier approach for application code.** When a version gap affects application code, pick the lowest tier that works:
+
+1. **Tier 1: Unconditional migration (preferred).** Both versions accept the new form, so just use it everywhere. This covers the typical Rails deprecation case because Rails ships the replacement one version before it removes the old form.
+2. **Tier 2: `NextRails.next?` conditional at the call site.** The new API doesn't exist on current, or the old one raises on next, and the affected call sites are few (up to ~20).
+3. **Tier 3: Backport or forwardport shim.** The gap spans an application layer (all controllers, all mailers, all models with the same concern) or affects ~20+ call sites. A single monkey-patch in one initializer (for runtime gaps) or `test_helper.rb` / `spec_helper.rb` (for test-only gaps) keeps call sites identical on both sides and collapses to a single-file delete at cleanup.
+
+See `references/code-patterns.md` "Three-Tier Approach" for the full decision framework, cleanup semantics per tier, and the Tier 3 `ActionController::Parameters#values` backport example.
+
+**Tier 2 illustration, `ignored_columns` (Rails 4.2 → 5.0):**
 
 ❌ **WRONG — Do NOT use feature detection (`respond_to?`, `defined?`, etc.):**
 ```ruby
@@ -74,14 +96,17 @@ Put the next-version branch on top so cleanup is mechanical: after the upgrade, 
 
 ### When to Apply
 
-Use `NextRails.next?` branching for:
+Most dual-boots only use `next?` in the Gemfile. App-code branching (Tier 2 or Tier 3) is reserved for genuine two-sided breakage where migrating to a common API (Tier 1) isn't possible. Reach for a call-site conditional or a shim when:
+
 - **Removed methods or constants** where the replacement only exists on the new side (e.g., a gem-provided method replaced by a native Rails method with different syntax)
 - **Incompatible signature or return-type changes** where the old and new forms genuinely fail on opposite sides
 - **Gem version differences** where the gem's API is different across versions pinned to each Rails version
 - **Initializer changes** where a config or middleware raises on one side
 - **Ruby version differences** (e.g., syntax changes, stdlib removals)
 
-**Not a reason to branch:** plain deprecation warnings. If the new API works on both versions (e.g. `config.fixture_path=` → `config.fixture_paths=`, `update_attributes` → `update` before its removal), migrate the call site directly — do not wrap it in `NextRails.next?`. See `references/code-patterns.md` "When NOT to Branch: Deprecations".
+Whether to resolve the gap with a call-site conditional (Tier 2) or a single shim (Tier 3) depends on how many call sites are affected and whether the gap spans a whole application layer. See `references/code-patterns.md` "Three-Tier Approach".
+
+**Not a reason to branch:** plain deprecation warnings. If the new API works on both versions (e.g. `config.fixture_path=` → `config.fixture_paths=`, `update_attributes` → `update` before its removal), migrate the call site directly. Do not wrap it in `NextRails.next?`. See `references/code-patterns.md` "Tier 1: Unconditional Migration".
 
 ---
 
@@ -110,17 +135,24 @@ Claude should activate this skill when user says:
 See `workflows/setup-workflow.md` for the complete step-by-step process.
 
 **Summary:**
-0. Verify deprecation warnings are not silenced (see `references/deprecation-tracking.md`)
-1. Check if dual-boot is already set up (look for `Gemfile.next`)
-2. Add `next_rails` gem to Gemfile
-3. Run `bundle install`
-4. Run `next_rails --init` (only if `Gemfile.next` does NOT exist)
-5. Configure Gemfile with `next?` conditionals for the dependency being upgraded
-  6. Install dependencies for both versions:
-     - Current: `bundle install`
-     - Next: `cp Gemfile.lock Gemfile.next.lock && BUNDLE_GEMFILE=Gemfile.next bundle install`
 
-7. Verify both versions work
+*Phase 1, preparatory (before any Rails version hop):*
+1. Verify deprecation warnings are not silenced (see `references/deprecation-tracking.md`)
+2. Check if dual-boot is already set up (look for `Gemfile.next`)
+3. Add `next_rails` gem at the Gemfile root and run `bundle install`
+4. Run `next_rails --init` (only if `Gemfile.next` does NOT exist)
+5. Configure `DeprecationTracker` (ask upfront whether CI runs tests in parallel)
+6. Capture the deprecation inventory: `DEPRECATION_TRACKER=save bundle exec rspec`
+7. Fix current-side deprecations unconditionally (Tier 1, no `NextRails.next?`)
+
+*Phase 2, dual-boot (the version hop):*
+8. Configure the Gemfile with the `if next?` version conditional
+9. Identify and pin incompatible gems via `bundle_report compatibility --rails-version=<target>`
+10. Install dependencies for both versions:
+    - Current: `bundle install`
+    - Next: `cp Gemfile.lock Gemfile.next.lock && BUNDLE_GEMFILE=Gemfile.next bundle install`
+11. Verify both sides boot and run tests
+12. Fix two-sided breakage using Tier 2 or Tier 3 (`references/code-patterns.md`)
 
 ### Workflow 2: Add Version-Dependent Code
 
@@ -143,13 +175,13 @@ See `workflows/cleanup-workflow.md` for the complete post-upgrade cleanup proces
 
 **Summary:**
 1. Search for all `NextRails.next?` references
-2. Keep only the `NextRails.next?` (true) branch code
-3. Remove all `else` branches
-4. Remove `next?` method from Gemfile
+2. At each call site, keep only the `NextRails.next?` (true) branch and remove the `else` branch (Tier 2 cleanup)
+3. Delete backport/forwardport shim files whose outermost guard is `if NextRails.next?` or `if !NextRails.next?` (Tier 3 cleanup)
+4. Remove `next?` method and `if next?` blocks from Gemfile
 5. Remove `next_rails` gem if no longer needed
 6. Remove `Gemfile.next` and replace `Gemfile.lock` with `Gemfile.next.lock`
-7. Update CI to remove dual-boot configuration
-8. Run full test suite
+7. Run full test suite
+8. Update CI to remove dual-boot configuration
 9. Commit cleanup changes
 
 ---

--- a/dual-boot/SKILL.md
+++ b/dual-boot/SKILL.md
@@ -46,9 +46,9 @@ When code would break on one version and needs a different implementation on the
 
 ### Pattern
 
-Every dual-boot has exactly one conditional that is always required: the Gemfile version pin. That is the canonical use of `next?`. App-code `NextRails.next?` is the exception, reserved for genuine two-sided breakage that cannot be resolved by migrating to a common API.
+Every dual-boot has exactly one conditional that is always required: the Gemfile version pin. That is the foundational use of `next?`. App-code `NextRails.next?` is the exception, reserved for genuine two-sided breakage that cannot be resolved by migrating to a common API.
 
-**The canonical conditional, the Gemfile version pin:**
+**The foundational conditional, the Gemfile version pin:**
 ```ruby
 # Gemfile
 if next?
@@ -106,7 +106,7 @@ Most dual-boots only use `next?` in the Gemfile. App-code branching (Tier 2 or T
 
 Whether to resolve the gap with a call-site conditional (Tier 2) or a single shim (Tier 3) depends on how many call sites are affected and whether the gap spans a whole application layer. See `references/code-patterns.md` "Three-Tier Approach".
 
-**Not a reason to branch:** plain deprecation warnings. If the new API works on both versions (e.g. `config.fixture_path=` → `config.fixture_paths=`, `update_attributes` → `update` before its removal), migrate the call site directly. Do not wrap it in `NextRails.next?`. See `references/code-patterns.md` "Tier 1: Unconditional Migration".
+**Not a reason to branch:** plain deprecation warnings. If the new API works on both versions (e.g. `config.fixture_path=` → `config.fixture_paths=`, `update_attributes` → `update` before its removal), migrate the call site directly. Do not wrap it in `NextRails.next?`. This is typical for Rails at adjacent-minor boundaries because Rails ships the replacement API one version before removing the old form. Non-adjacent hops or third-party gems may have more genuine two-sided breaks. See `references/code-patterns.md` "Tier 1: Unconditional Migration".
 
 ---
 

--- a/dual-boot/examples/basic-setup.md
+++ b/dual-boot/examples/basic-setup.md
@@ -8,6 +8,20 @@ You have a Rails 4.2 application and want to upgrade to Rails 5.0. You want to s
 
 ---
 
+## Before You Start: Resolve Current-Version Deprecations
+
+Dual-boot is the workflow for handling genuine two-sided breakage between the current and next Rails versions. Before you get there, resolve the deprecation warnings your application already emits on its **current** Rails version (4.2 in this example). Those warnings are the roadmap for the hop: each one names an API that will fail on the next side. Fixing them up front turns most of the apparent "upgrade work" into routine current-version cleanup, and leaves only the genuinely two-sided problems for dual-boot to address.
+
+Resolve current-version deprecations unconditionally (Tier 1 in the three-tier framework). Rails ships the replacement API one version before it removes the old form, so the new call almost always works on both the current and next sides. That means no `NextRails.next?` branch is needed, and wrapping a plain deprecation fix in a conditional produces a dead branch you will only have to clean up later. Save `NextRails.next?` for Step 6, where it addresses real two-sided breakage.
+
+To get visibility into the full inventory of current-version deprecations and track them as you fix each one, see `references/deprecation-tracking.md` for `DeprecationTracker` setup. One sequencing note: configure `DeprecationTracker` **before** running the test suite for the first time. A single run then captures the complete set of warnings, avoiding a double pass just to build the inventory.
+
+If you are following the broader Rails upgrade methodology from the rails-upgrade skill, current-version deprecation resolution is a prerequisite to the dual-boot hop, not a step inside it. The workflow below assumes that preparatory pass is done.
+
+See `references/code-patterns.md` "Three-Tier Approach" for the full framing of Tier 1 (unconditional migration) versus Tier 2 and Tier 3.
+
+---
+
 ## Step-by-Step
 
 ### 1. Add `next_rails` to Gemfile

--- a/dual-boot/examples/basic-setup.md
+++ b/dual-boot/examples/basic-setup.md
@@ -71,6 +71,10 @@ BUNDLE_GEMFILE=Gemfile.next bundle install
 
 ### 5. Run Tests Against Both
 
+This example uses RSpec. If your project uses Minitest, substitute `bin/rails test` (or `rake test`) for `bundle exec rspec` throughout. The `BUNDLE_GEMFILE=Gemfile.next` prefix works with any test runner. See `workflows/setup-workflow.md` Step 11 for the full detection logic (RSpec, Minitest, `bin/test`, `parallel_tests`, `turbo_tests`).
+
+**RSpec:**
+
 ```bash
 # Current version (4.2)
 bundle exec rspec
@@ -79,6 +83,16 @@ bundle exec rspec
 # Next version (5.0)
 BUNDLE_GEMFILE=Gemfile.next bundle exec rspec
 # => Some failures — fix using NextRails.next? branching
+```
+
+**Minitest equivalent:**
+
+```bash
+# Current version (4.2)
+bin/rails test
+
+# Next version (5.0)
+BUNDLE_GEMFILE=Gemfile.next bin/rails test
 ```
 
 ### 6. Fix a Breaking Change

--- a/dual-boot/references/code-patterns.md
+++ b/dual-boot/references/code-patterns.md
@@ -10,7 +10,7 @@ The version numbers in the example below are from a Rails 4.2 → 5.0 upgrade, b
 
 ---
 
-## The Canonical Case: Gemfile Version Pin
+## The Foundational Case: Gemfile Version Pin
 
 ### `ActionController::TestRequest.new` → `.create` (Rails 4.2 → 5.0)
 
@@ -25,7 +25,7 @@ test_request =
   end
 ```
 
-This is genuinely two-sided — the `7.1.0` pin fails resolution on the 7.0 side and vice versa — so the conditional is required for bundler to resolve at all. Every other use of `NextRails.next?` is secondary.
+This is genuinely two-sided — the `7.1.0` pin fails resolution on the 7.0 side and vice versa — so the conditional is required for bundler to resolve at all. Every other use of `NextRails.next?` is secondary (Tier 2 or 3).
 
 ---
 

--- a/dual-boot/references/code-patterns.md
+++ b/dual-boot/references/code-patterns.md
@@ -10,7 +10,7 @@ The version numbers in the example below are from a Rails 4.2 → 5.0 upgrade, b
 
 ---
 
-## Rails API Changes Requiring a Conditional
+## The Canonical Case: Gemfile Version Pin
 
 ### `ActionController::TestRequest.new` → `.create` (Rails 4.2 → 5.0)
 
@@ -25,11 +25,32 @@ test_request =
   end
 ```
 
+This is genuinely two-sided — the `7.1.0` pin fails resolution on the 7.0 side and vice versa — so the conditional is required for bundler to resolve at all. Every other use of `NextRails.next?` is secondary.
+
 ---
 
-## When NOT to Branch: Deprecations
+## Three-Tier Approach for Application Code
 
-If the **new** API exists on the current version too, there is no breaking change — just replace the call site. Wrapping a deprecation in `NextRails.next?` adds dead branches you'll have to clean up for no benefit.
+When a version gap affects application code (not the Gemfile), pick the **lowest tier that works**. Lower tiers are cheaper to read, cheaper to clean up, and do not leave dead branches behind. Climb tiers only when the lower option actually breaks.
+
+| Tier | Technique | When |
+|------|-----------|------|
+| 1 | Unconditional migration — use the new API on both sides. | Both Rails versions accept the new form (the typical Rails deprecation case). |
+| 2 | `NextRails.next?` conditional at the call site. | New API doesn't exist on current (or old API raises on next). Smaller gaps (up to ~20 call sites). |
+| 3 | Backport / forwardport shim — monkey-patch in one file. | Same gap spans an application layer (all controllers, all mailers) or affects ~20+ call sites. |
+
+**Cleanup at the end of the dual-boot is mechanical in all three tiers:**
+- Tier 1 — nothing to clean; the code is already unconditional.
+- Tier 2 — drop `else` branches, keep the `if NextRails.next?` body.
+- Tier 3 — delete the shim file.
+
+See `workflows/cleanup-workflow.md` for the full cleanup procedure.
+
+---
+
+### Tier 1: Unconditional Migration (preferred)
+
+If the **new** API exists on the current version too, there is no breaking change — just replace the call site. Wrapping a deprecation in `NextRails.next?` adds dead branches you'll have to clean up for no benefit. This is the case for almost every Rails-core deprecation at an adjacent-minor boundary because Rails ships the replacement one version before it removes the old form.
 
 ❌ **WRONG — `fixture_path` → `fixture_paths` (deprecation only):**
 
@@ -50,6 +71,75 @@ config.fixture_paths = ["#{::Rails.root}/spec/fixtures"]
 ```
 
 Same rule applies to `serialize :preferences, coder: JSON` vs. the older positional form, `update` vs. `update_attributes` (prior to the 6.1 removal), and most Rails API evolution: if both versions accept the new form, migrate call sites directly and skip the conditional.
+
+---
+
+### Tier 2: `NextRails.next?` Conditional (for a few call sites)
+
+Reach for a conditional when the gap is genuinely two-sided — the new API doesn't exist on current, or the old one raises on next — and the affected call sites are few (up to ~20). Common triggers:
+
+- **A third-party gem tied to the Rails version has a two-sided API break.** Rails versions often pull in different majors of gems like Rack, minitest, or rspec-rails, or a Rails major replaces a gem-provided feature with a native API using different syntax.
+- **You treat deprecations as errors** via `ActiveSupport::Deprecation.behavior = :raise`. A deprecated-but-still-working Rails call now raises on the next side, so the branch lets you use the new API on next and keep the old form on current.
+- **The Rails upgrade also forces a Ruby upgrade** with stdlib extractions or syntax differences.
+
+**Example — `ignorable` gem → native `ignored_columns=` (Rails 4.2 → 5.0):**
+
+An app using the [`ignorable`](https://github.com/nthj/ignorable) gem to ignore columns on Rails 4.2 hits a genuine two-sided case when upgrading to 5.0, which introduced a native `ignored_columns=` with different syntax. If the gem is dropped on the 5.0 side (since Rails now has the feature), `ignore_columns :category` raises `NoMethodError` there; `self.ignored_columns += [:category]` raises `NoMethodError` on 4.2 where the setter doesn't exist yet.
+
+```ruby
+# app/models/project.rb
+class Project < ActiveRecord::Base
+  if NextRails.next?
+    self.ignored_columns += [:category]
+  else
+    ignore_columns :category
+  end
+end
+```
+
+Put the next-version branch on top so cleanup is mechanical: after the upgrade, keep the `if` body and drop the `else`.
+
+---
+
+### Tier 3: Backport / Forwardport Shim (for many call sites)
+
+When a version gap spans an application layer (all controllers, all mailers, all models with the same concern) or affects ~20+ call sites, a single monkey-patch in an initializer (for runtime gaps) or `test_helper.rb` / `spec_helper.rb` (for test-only gaps) lets all call sites stay identical on both sides. The shim makes the lagging version behave like the other one — usually by redefining a method to delegate to an existing equivalent. This is cleaner than scattering dozens of `NextRails.next?` branches and much simpler to remove at cleanup: delete the shim file.
+
+**Two directions:**
+- **Backport** — teach the *current* (older) version to behave like the next one, so all call sites are written using the new shape. More common because the new shape is usually the one you want to keep after cleanup.
+- **Forwardport** — teach the *next* (newer) version to behave like the current one, so existing call sites keep working unchanged while you migrate them gradually.
+
+Pick whichever direction lets the shared call-site code read best.
+
+**Example — `ActionController::Parameters#values` backport (Rails 7.0 → 7.1):**
+
+Rails 7.1 changed [`ActionController::Parameters#values`](https://github.com/rails/rails/pull/44816) to return an array of `ActionController::Parameters` objects instead of an array of plain hashes. Any controller or service that calls `params.values` and treats the result as hashes will behave differently between the two sides. With many such call sites, a shim is cleaner than scattering conditionals:
+
+```ruby
+# config/initializers/ac_parameters_values_backport.rb
+
+# Backport of Rails 7.1's ActionController::Parameters#values behavior so that
+# call sites on the Rails 7.0 side also receive an array of
+# ActionController::Parameters (not plain hashes).
+# Delete this file once the upgrade to Rails 7.1 is complete.
+# Reference: https://github.com/rails/rails/pull/44816
+
+if !NextRails.next?
+  module ActionController
+    class Parameters
+      def values
+        to_enum(:each_value).to_a
+      end
+    end
+  end
+end
+```
+
+With the shim loaded, every `params.values` call across the app returns the 7.1 shape on both sides — no per-call-site branching. After the upgrade, delete `ac_parameters_values_backport.rb` and nothing else needs to change.
+
+**Caveats for Tier 3:**
+- Monkey-patches affect the whole process. Keep the shim narrow (one or two methods), well-commented with a removal marker, and guarded with `if !NextRails.next?` (for a backport) or `if NextRails.next?` (for a forwardport) so it only loads on the side that needs it.
+- If the signature difference between versions is severe enough that a faithful shim isn't possible, fall back to Tier 2 — a conditional at each call site is clearer than a lossy shim.
 
 ---
 

--- a/dual-boot/references/code-patterns.md
+++ b/dual-boot/references/code-patterns.md
@@ -29,7 +29,7 @@ This is genuinely two-sided — the `7.1.0` pin fails resolution on the 7.0 side
 
 ---
 
-## Three-Tier Approach for Application Code
+## Three-Tier Approach
 
 When a version gap affects application code (not the Gemfile), pick the **lowest tier that works**. Lower tiers are cheaper to read, cheaper to clean up, and do not leave dead branches behind. Climb tiers only when the lower option actually breaks.
 

--- a/dual-boot/references/deprecation-tracking.md
+++ b/dual-boot/references/deprecation-tracking.md
@@ -6,7 +6,7 @@
 
 ## Why This Matters
 
-Deprecation warnings are your roadmap during a Rails upgrade — they tell you exactly what will break in the next version. If deprecations are silenced, you're flying blind. Before setting up dual-boot, you must ensure deprecation warnings are visible and tracked.
+Deprecation warnings are your roadmap during a Rails upgrade. They tell you exactly what will break in the next version. If deprecations are silenced, you're flying blind. Before setting up dual-boot, you must ensure deprecation warnings are visible and tracked.
 
 ---
 
@@ -17,16 +17,16 @@ Check these files for silenced deprecations:
 ### Check `config/environments/test.rb`
 
 ```ruby
-# BAD — deprecations are invisible
+# BAD (deprecations are invisible)
 config.active_support.deprecation = :silence
 
-# BAD — all deprecation behaviors disabled (Rails 7.0+)
+# BAD (all deprecation behaviors disabled, Rails 7.0+)
 config.active_support.report_deprecations = false
 ```
 
 ### Check `config/environments/development.rb`
 
-Same patterns as above — `:silence` or `report_deprecations = false`.
+Same patterns as above: `:silence` or `report_deprecations = false`.
 
 ### Check for Global Silencing
 
@@ -60,19 +60,21 @@ If any of these are silencing deprecations, fix them before proceeding with the 
 
 The `next_rails` gem includes `DeprecationTracker` which captures all deprecation warnings during test runs and saves them to a file. This gives you a complete inventory without stopping on the first failure (unlike `:raise`).
 
+> **Minimum `next_rails` version: 1.5.0** (released 2026-04-02). The parallel-CI-aware `node_index:` option and the `deprecations merge` CLI require v1.5.0. If your Gemfile currently pins an older version, update it before proceeding.
+
 ### Setup
 
-Ensure `next_rails` is in your Gemfile at the **root level** (not inside a `group` block):
+Ensure `next_rails` is in your Gemfile at the **root level** (not inside a `group` block), with the version constraint:
 
 ```ruby
 # Gemfile
-# MUST be at root level — not in :development or :test group
-gem 'next_rails'
+# MUST be at root level, not in :development or :test group
+gem 'next_rails', '>= 1.5.0'
 ```
 
 Then configure your test runner.
 
-**RSpec** — in `spec/spec_helper.rb` (or `spec/rails_helper.rb`):
+**RSpec**, in `spec/spec_helper.rb` (or `spec/rails_helper.rb`):
 
 ```ruby
 RSpec.configure do |config|
@@ -85,7 +87,7 @@ RSpec.configure do |config|
 end
 ```
 
-**Minitest** — in `test/test_helper.rb`:
+**Minitest**, in `test/test_helper.rb`:
 
 ```ruby
 DeprecationTracker.track_minitest(
@@ -95,19 +97,19 @@ DeprecationTracker.track_minitest(
 )
 ```
 
-- **`shitlist_path`** — where to save/read the deprecation inventory (required, no default)
-- **`mode`** — defaults to `save` so it always tracks
-- **`transform_message`** — strips the Rails root path from messages so the shitlist is portable across environments
+- **`shitlist_path`**: where to save/read the deprecation inventory (required, no default)
+- **`mode`**: defaults to `save` so it always tracks
+- **`transform_message`**: strips the Rails root path from messages so the shitlist is portable across environments
 
 ### Save the Deprecation Shitlist
 
-Run the test suite with `DEPRECATION_TRACKER=save` to collect all deprecation warnings (substitute your project's test command — e.g. `bundle exec rspec`, `bin/rails test`, `bin/test`):
+Run the test suite with `DEPRECATION_TRACKER=save` to collect all deprecation warnings (substitute your project's test command, e.g. `bundle exec rspec`, `bin/rails test`, `bin/test`):
 
 ```bash
 DEPRECATION_TRACKER=save bundle exec rspec
 ```
 
-This generates `spec/support/deprecation_warning.shitlist.json` — a JSON file listing every unique deprecation warning found during the run.
+This generates `spec/support/deprecation_warning.shitlist.json`, a JSON file listing every unique deprecation warning found during the run.
 
 > **Note:** Make sure the directory for `shitlist_path` exists before running.
 
@@ -117,55 +119,116 @@ Once you have a shitlist, run with `DEPRECATION_TRACKER=save` after fixing depre
 
 ### Workflow
 
-1. `DEPRECATION_TRACKER=save bundle exec rspec` — generates initial shitlist
+1. `DEPRECATION_TRACKER=save bundle exec rspec` generates the initial shitlist
 2. Review the shitlist to understand the scope of deprecations
 3. Fix one category of deprecation (e.g., `update_attributes`)
-4. `DEPRECATION_TRACKER=save bundle exec rspec` — updates the shitlist (it should shrink)
+4. `DEPRECATION_TRACKER=save bundle exec rspec` updates the shitlist (it should shrink)
 5. Repeat until the shitlist is empty
 6. Commit the shitlist file so the team tracks progress together
 
 ### CI with Parallel Test Execution
 
-`DeprecationTracker` does not natively support parallel execution. When CI splits tests across multiple nodes/containers (e.g., CircleCI parallelism, parallel_tests gem), each node only sees its subset of deprecations. You need to collect and merge the results.
+Starting with `next_rails` v1.5.0, `DeprecationTracker` has native support for parallel CI. When CI splits tests across multiple nodes or containers (CircleCI parallelism, Buildkite, GitLab, Semaphore, GitHub Actions matrix), each node writes its own shard file. A one-off merge step fans the shards back into the canonical shitlist.
 
-**Strategy: Save per-node, merge after**
+#### Configure `node_index:`
 
-1. On each CI node, run with `DEPRECATION_TRACKER=save` as normal
-2. Each node produces its own `spec/support/deprecation_warning.shitlist.json`
-3. After all nodes finish, collect and merge the shitlist files:
+Pass a `node_index:` value to `track_rspec` or `track_minitest`. When set, the tracker writes to `<shitlist_path>.node-<index>.json` instead of the canonical file, so parallel nodes don't clobber each other.
 
-```bash
-# Example merge script (run after all parallel nodes complete)
-# Collects shitlist JSON files from each node and merges them
+You can pass `node_index:` explicitly, or omit it and rely on auto-detection from standard CI environment variables:
 
-require 'json'
+| CI platform | Env var auto-detected |
+|---|---|
+| CircleCI | `CIRCLE_NODE_INDEX` |
+| Buildkite | `BUILDKITE_PARALLEL_JOB` |
+| GitLab CI | `CI_NODE_INDEX` |
+| Semaphore | `SEMAPHORE_JOB_INDEX` |
+| Generic | `CI_NODE_INDEX` |
 
-shitlists = Dir.glob("node-*/spec/support/deprecation_warning.shitlist.json")
-merged = {}
+**RSpec** with explicit `node_index:`:
 
-shitlists.each do |file|
-  data = JSON.parse(File.read(file))
-  data.each do |key, values|
-    merged[key] ||= []
-    merged[key] = (merged[key] + values).uniq
+```ruby
+RSpec.configure do |config|
+  if ENV["DEPRECATION_TRACKER"]
+    DeprecationTracker.track_rspec(
+      config,
+      shitlist_path: "spec/support/deprecation_warning.shitlist.json",
+      mode: ENV.fetch("DEPRECATION_TRACKER", "save"),
+      node_index: ENV["CI_NODE_INDEX"],
+      transform_message: -> (message) { message.gsub("#{Rails.root}/", "") }
+    )
   end
 end
-
-File.write("spec/support/deprecation_warning.shitlist.json", JSON.pretty_generate(merged))
 ```
 
-The exact collection mechanism depends on your CI setup:
-- **CircleCI**: Use `persist_to_workspace` / `attach_workspace` to gather shitlists from parallel containers
-- **GitHub Actions**: Use `upload-artifact` / `download-artifact` across matrix jobs
-- **parallel_tests gem**: Each process writes to the same filesystem, so you can glob the results directly
+If your CI sets one of the env vars in the table above, you can drop the `node_index:` argument entirely and let auto-detection handle it.
 
-> **Tip:** Run the initial `DEPRECATION_TRACKER=save` locally (non-parallel) to generate the first complete shitlist. Use the parallel merge strategy in CI for ongoing regression checks.
+**Minitest** with the same pattern:
+
+```ruby
+DeprecationTracker.track_minitest(
+  shitlist_path: "test/support/deprecation_warning.shitlist.json",
+  mode: ENV.fetch("DEPRECATION_TRACKER", "save"),
+  node_index: ENV["CI_NODE_INDEX"],
+  transform_message: -> (message) { message.gsub("#{Rails.root}/", "") }
+)
+```
+
+#### Three-phase CI workflow
+
+**Save phase** (each parallel node writes a shard):
+
+```bash
+DEPRECATION_TRACKER=save CI_NODE_INDEX=$NODE bundle exec rspec <subset>
+```
+
+Each node produces a file like `spec/support/deprecation_warning.shitlist.node-0.json`, `...node-1.json`, etc.
+
+**Merge phase** (runs once after all nodes finish, with shards gathered into one workspace):
+
+```bash
+deprecations merge --delete-shards
+```
+
+This fans all shards into the canonical `spec/support/deprecation_warning.shitlist.json` and removes the per-node files. To merge the next-Rails shitlist (the shards produced when running under the next Rails version in dual-boot), pass `--next`:
+
+```bash
+deprecations merge --next --delete-shards
+```
+
+For custom flows, call the programmatic form directly:
+
+```ruby
+DeprecationTracker.merge_shards(
+  "spec/support/deprecation_warning.shitlist.json",
+  delete_shards: true
+)
+```
+
+**Compare phase** (each parallel node compares its subset against the merged canonical file):
+
+```bash
+DEPRECATION_TRACKER=compare CI_NODE_INDEX=$NODE bundle exec rspec <subset>
+```
+
+The shard/canonical split means compare mode works per-node without false positives: each node only checks deprecations it actually emits, and the canonical shitlist already contains every deprecation from every node.
+
+#### Gathering shards between phases
+
+The exact mechanism to move shards from save-phase nodes into the merge job depends on your CI:
+
+- **CircleCI**: use `persist_to_workspace` in each parallel container, `attach_workspace` in the merge job
+- **GitHub Actions**: use `upload-artifact` from each matrix job, `download-artifact` in the merge job
+- **Buildkite**: use pipeline artifacts (`buildkite-agent artifact upload` / `download`)
+- **GitLab CI**: use job artifacts with `dependencies:` in the merge job
+- **parallel_tests gem (single host)**: each process writes to the same filesystem, so the merge step can run immediately without any artifact shuffle
+
+> **Tip:** Run the initial `DEPRECATION_TRACKER=save` locally without `node_index:` to generate the first complete canonical shitlist. Use the parallel sharded workflow in CI for ongoing regression checks.
 
 ### Limitations
 
-- **Not compatible with `minitest/parallel_fork`** — use standard minitest or RSpec
-- **No native parallel support** — requires manual merge when using CI parallelism (see above)
-- **Supports RSpec (`track_rspec`) and Minitest (`track_minitest`)** — other frameworks require manual integration
+- **Not compatible with `minitest/parallel_fork`.** Use standard Minitest, RSpec, or the custom deprecation behavior approach below.
+- **Requires `next_rails` >= 1.5.0** for native parallel CI support. Older versions need a manual merge script.
+- **Supports RSpec (`track_rspec`) and Minitest (`track_minitest`).** Other frameworks require manual integration.
 
 ---
 
@@ -197,7 +260,7 @@ config.active_support.deprecation = :log
 ```ruby
 # config/initializers/custom_deprecation_behavior.rb
 ActiveSupport::Deprecation.behavior = ->(message, callstack, deprecation_horizon, gem_name) {
-  # Deprecations you've already fixed — raise if they reappear
+  # Deprecations you've already fixed, raise if they reappear
   disallowed = [
     "update_attributes",
     /before_filter/,
@@ -277,4 +340,17 @@ After completing the upgrade:
 | Current behavior | `grep -rn "active_support.deprecation" .` |
 | Custom behaviors | `grep -rn "Deprecation.behavior" .` |
 | Save deprecation inventory | `DEPRECATION_TRACKER=save bundle exec rspec` |
+| Merge parallel shards | `deprecations merge --delete-shards` |
 | Existing warnings | `bundle exec rspec 2>&1 \| grep "DEPRECATION WARNING"` |
+
+---
+
+## Last-resort fallback
+
+If `DeprecationTracker` won't install or configure on your app (rare, see Limitations), you can capture deprecations by tailing the test log:
+
+```bash
+bundle exec rspec 2>&1 | grep "DEPRECATION WARNING" | sort -u
+```
+
+This loses structure, compare mode, and regression gating. Use `DeprecationTracker` when possible.

--- a/dual-boot/workflows/cleanup-workflow.md
+++ b/dual-boot/workflows/cleanup-workflow.md
@@ -53,7 +53,7 @@ Step 2 removes branches at individual call sites. Tier-3 shims are different: an
 grep -rln -E "^if\s*!?NextRails\.next\?\s*$" config/initializers/ test/ spec/
 ```
 
-The pattern matches files whose guard is on its own line at the start of a line. If your project keeps shims in other locations, broaden the search paths accordingly.
+This grep is a heuristic starting point, not definitive. It matches files whose guard is on its own line at the start. If your project keeps shims in other locations, broaden the search paths accordingly. **Every match requires manual verification — not every file with `if NextRails.next?` at the top level is a shim.**
 
 ### Verify each match is a shim, not a regular call-site branch:
 

--- a/dual-boot/workflows/cleanup-workflow.md
+++ b/dual-boot/workflows/cleanup-workflow.md
@@ -22,9 +22,9 @@ This lists all files that contain dual-boot branching code.
 
 ---
 
-## Step 2: Remove Dual-Boot Branches
+## Step 2: Remove Dual-Boot Branches (Tier 2 cleanup)
 
-For each file found in Step 1, keep only the `NextRails.next?` (true) branch and remove the `else` branch.
+For each file found in Step 1, keep only the `NextRails.next?` (true) branch and remove the `else` branch. This step handles per-call-site conditionals, where a single `if NextRails.next? / else` sits inside a method, a class body, or a config block.
 
 ### Before:
 ```ruby
@@ -43,7 +43,36 @@ test_request = ActionController::TestRequest.create
 
 ---
 
-## Step 3: Clean Up the Gemfile
+## Step 3: Delete Backport / Forwardport Shim Files (Tier 3 cleanup)
+
+Step 2 removes branches at individual call sites. Tier-3 shims are different: an entire file exists only to make one side of the dual-boot behave like the other, typically a monkey-patch in `config/initializers/` (runtime gaps) or in `test/test_helper.rb` / `spec/spec_helper.rb` (test-only gaps). The file's outermost construct is an `if NextRails.next?` or `if !NextRails.next?` guard that wraps a `module`/`class` redefinition, and the rest of the file is the body of that guard.
+
+### Find candidate shim files:
+
+```bash
+grep -rln -E "^if\s*!?NextRails\.next\?\s*$" config/initializers/ test/ spec/
+```
+
+The pattern matches files whose guard is on its own line at the start of a line. If your project keeps shims in other locations, broaden the search paths accordingly.
+
+### Verify each match is a shim, not a regular call-site branch:
+
+Open the file and look at what the guard wraps:
+
+- **Tier-3 shim**: the guard wraps a `module X; class Y; def foo; ...; end; end; end` redefinition (or a similar `class_eval` / `prepend` block that redefines behavior process-wide). The entire file exists to install that patch.
+- **Not a shim**: the guard wraps a single method call, a config setting, or a small block that happens to live at the top level of a Ruby file. That is a Tier-2 call-site branch and was already handled in Step 2.
+
+### Delete the file:
+
+```bash
+git rm config/initializers/ac_parameters_values_backport.rb
+```
+
+Delete the whole file, not just the `if` guard. The file exists only for the shim. On the target version, the guard was already false (backport) or redundant (forwardport), so the shim never ran or no longer applies, and deleting it has no runtime effect on the surviving side.
+
+---
+
+## Step 4: Clean Up the Gemfile
 
 ### Remove the `next?` method definition:
 
@@ -74,7 +103,7 @@ gem 'rails', '~> 7.1.0'
 
 ---
 
-## Step 4: Remove `next_rails` Gem
+## Step 5: Remove `next_rails` Gem
 
 If the gem is no longer needed:
 
@@ -85,7 +114,7 @@ gem 'next_rails'
 
 ---
 
-## Step 5: Remove Dual-Boot Files and Preserve Lock Versions
+## Step 6: Remove Dual-Boot Files and Preserve Lock Versions
 
 Replace `Gemfile.lock` with `Gemfile.next.lock` to keep the exact gem versions that were tested during the upgrade, and remove `Gemfile.next` which is no longer needed — running `bundle install` from scratch could resolve to different versions.
 
@@ -96,7 +125,7 @@ mv Gemfile.next.lock Gemfile.lock
 
 ---
 
-## Step 6: Run Full Test Suite
+## Step 7: Run Full Test Suite
 
 Run the project's detected test command (see SKILL.md Key Principle #4). Pick the one that matches this project:
 
@@ -117,13 +146,13 @@ Ensure all tests pass without dual-boot.
 
 ---
 
-## Step 7: Update CI Configuration
+## Step 8: Update CI Configuration
 
 Remove the dual-boot CI job/matrix entry that ran tests with `BUNDLE_GEMFILE=Gemfile.next`.
 
 ---
 
-## Step 8: Commit Cleanup
+## Step 9: Commit Cleanup
 
 ```bash
 git add -A

--- a/dual-boot/workflows/setup-workflow.md
+++ b/dual-boot/workflows/setup-workflow.md
@@ -1,47 +1,41 @@
 # Dual-Boot Setup Workflow
 
+This workflow is split into two phases:
+
+- **Phase 1 (Preparatory):** Install `next_rails`, set up `DeprecationTracker`, and resolve current-version deprecations unconditionally (Tier 1). No Rails version hop yet. Both `Gemfile` and `Gemfile.next` resolve to identical gems.
+- **Phase 2 (Dual-Boot):** Pin a different Rails version in the `if next?` Gemfile block, install gems on the next side, and fix genuine two-sided breakage using Tier 2 or Tier 3 patterns.
+
+Keeping deprecation resolution in Phase 1 means most deprecation fixes land as plain, unconditional migrations on the current Rails version, without any `NextRails.next?` branching. Phase 2 is then scoped to the real two-sided breakage that only dual-boot can address.
+
 ## Prerequisites
 
-- A Ruby application with a working `Gemfile` and `Gemfile.lock`
-- Know the current and target versions for the dependency you are upgrading (Rails, Ruby, or another core gem)
+- A Ruby application with a working `Gemfile` and `Gemfile.lock`.
+- Know the current and target versions for the dependency you are upgrading (Rails, Ruby, or another core gem).
+- **Minimum `next_rails` version: 1.5.0** (released 2026-04-02). The parallel-CI-aware `DeprecationTracker` configuration (`node_index:` option) and the `deprecations merge --delete-shards` CLI require v1.5.0. If your Gemfile currently pins an older version, update it before proceeding.
 
 ---
 
-## Step 0: Verify Deprecation Warnings Are Not Silenced
+# Phase 1: Preparatory
 
-Before setting up dual-boot, ensure deprecation warnings are visible. Silenced deprecations mean you can't track upgrade progress.
+Phase 1 is everything you do **before** the Rails version hop. At the end of Phase 1 you have `next_rails` installed, `Gemfile.next` in place as a symlink (both sides resolve to the same gems), `DeprecationTracker` configured, and all current-side deprecations fixed unconditionally. No `NextRails.next?` conditionals appear in application code during this phase.
 
-**Check for silenced deprecations:**
+## Step 1: Verify Deprecation Warnings Are Not Silenced
 
-```bash
-grep -rn "deprecation.*silence\|silenced.*true\|report_deprecations.*false" config/
-```
+Before setting up dual-boot, ensure deprecation warnings are visible and tracked. See `references/deprecation-tracking.md` for the full procedure (detection of silenced deprecations, how to unsilence, and setting up `DeprecationTracker` to capture a regression-safe inventory).
 
-**If deprecations are silenced:**
-1. Change `:silence` to `:stderr` or `:log` (or `:raise` if you want strict mode)
-2. Remove `ActiveSupport::Deprecation.silenced = true` if found
-3. Remove `config.active_support.report_deprecations = false` if found (Rails 7.0+)
-4. Run the test suite to see current deprecation warnings
-
-See `references/deprecation-tracking.md` for detailed configuration guidance, including a gradual approach using custom deprecation behaviors for apps with many existing warnings.
-
----
-
-## Step 1: Check if Dual-Boot is Already Set Up
+## Step 2: Check if Dual-Boot is Already Set Up
 
 ```bash
 # Check if Gemfile.next already exists
 ls -la Gemfile.next
 ```
 
-- If `Gemfile.next` exists → Skip to Step 4
-- If `Gemfile.next` does NOT exist → Continue to Step 2
+- If `Gemfile.next` exists, skip Steps 3 and 4 (gem install and `next_rails --init`) and proceed to Step 5.
+- If `Gemfile.next` does not exist, continue to Step 3.
 
-**⚠️ CRITICAL:** Running `next_rails --init` when dual-boot is already set up will duplicate the `next?` method definition in the Gemfile, causing errors.
+**CRITICAL:** Running `next_rails --init` when dual-boot is already set up will duplicate the `next?` method definition in the Gemfile, causing errors.
 
----
-
-## Step 2: Add `next_rails` Gem
+## Step 3: Add the `next_rails` Gem
 
 Add the gem to the Gemfile **at the root level, not inside any group**:
 
@@ -50,13 +44,13 @@ Add the gem to the Gemfile **at the root level, not inside any group**:
 gem 'next_rails'
 ```
 
-**⚠️ If the gem is already present, verify its location.** Grep for it:
+**If the gem is already present, verify its location.** Grep for it:
 
 ```bash
 grep -n "next_rails" Gemfile
 ```
 
-If it lives inside a `group :development`, `group :test`, or `group :development, :test do ... end` block, move it outside. Any `NextRails.next?` in `config/environments/production.rb` or `config/application.rb` will raise `NameError: uninitialized constant NextRails` when the app boots in production (e.g., during `assets:precompile RAILS_ENV=production`). The gem must be loadable in every environment where conditional config runs.
+If it lives inside a `group :development`, `group :test`, or `group :development, :test do ... end` block, move it outside. Any `NextRails.next?` in `config/environments/production.rb` or `config/application.rb` will raise `NameError: uninitialized constant NextRails` when the app boots in production (for example, during `assets:precompile RAILS_ENV=production`). The gem must be loadable in every environment where conditional config runs.
 
 Then install:
 
@@ -64,23 +58,118 @@ Then install:
 bundle install
 ```
 
----
-
-## Step 3: Initialize Dual-Boot
+## Step 4: Initialize Dual-Boot
 
 ```bash
 next_rails --init
 ```
 
 This creates:
-- `Gemfile.next` — Symlink to your Gemfile
-- `Gemfile.next.lock` — Lock file for the next dependency set
+
+- `Gemfile.next`, a symlink to your `Gemfile`.
+- `Gemfile.next.lock`, the lockfile for the next dependency set.
+
+At this point both sides resolve to identical gems. The infrastructure is in place, but no version hop has happened yet.
+
+## Step 5: Configure `DeprecationTracker`
+
+`DeprecationTracker` (shipped with `next_rails`) captures every deprecation warning emitted during a test run and saves it to a JSON shitlist. Setting it up **before** the first test run means a single run captures the full inventory, avoiding a double pass.
+
+Before choosing a configuration, ask the user:
+
+> Do you run tests in CI with parallel execution (multiple nodes/containers running subsets of tests)?
+
+Pick the matching configuration below.
+
+### No / local only / single-process CI
+
+**RSpec**, add to `spec/spec_helper.rb` (or `spec/rails_helper.rb`):
+
+```ruby
+RSpec.configure do |config|
+  DeprecationTracker.track_rspec(
+    config,
+    shitlist_path: "spec/support/deprecation_warning.shitlist.json"
+  )
+end
+```
+
+**Minitest**, add to `test/test_helper.rb`:
+
+```ruby
+DeprecationTracker.track_minitest(
+  shitlist_path: "test/support/deprecation_warning.shitlist.json"
+)
+```
+
+### Yes, parallel CI
+
+Set `node_index:` to the environment variable your CI provider uses for the per-shard index (`CI_NODE_INDEX`, `CIRCLE_NODE_INDEX`, `BUILDKITE_PARALLEL_JOB`, `SEMAPHORE_JOB_INDEX`, and so on).
+
+**RSpec:**
+
+```ruby
+RSpec.configure do |config|
+  DeprecationTracker.track_rspec(
+    config,
+    shitlist_path: "spec/support/deprecation_warning.shitlist.json",
+    node_index: ENV["CI_NODE_INDEX"]  # or CIRCLE_NODE_INDEX, BUILDKITE_PARALLEL_JOB, etc.
+  )
+end
+```
+
+**Minitest:**
+
+```ruby
+DeprecationTracker.track_minitest(
+  shitlist_path: "test/support/deprecation_warning.shitlist.json",
+  node_index: ENV["CI_NODE_INDEX"]
+)
+```
+
+With `node_index:` set, each shard writes `deprecation_warning.shitlist.node-<N>.json` instead of the canonical file. After all nodes finish, a fan-in step runs:
+
+```bash
+deprecations merge --delete-shards
+```
+
+This merges every `node-<N>.json` shard into the canonical shitlist and removes the shard files. See `references/deprecation-tracking.md` for the full CI pipeline (save, merge, compare phases).
+
+## Step 6: Capture the Deprecation Inventory
+
+Run the test suite on current Rails with `DEPRECATION_TRACKER=save` to generate the initial shitlist:
+
+```bash
+DEPRECATION_TRACKER=save bundle exec rspec
+```
+
+(Substitute your project's test command: `bin/rails test`, `bin/test`, `bundle exec parallel_rspec spec/`, and so on. The `DEPRECATION_TRACKER=save` environment variable is what matters.)
+
+This creates `spec/support/deprecation_warning.shitlist.json`, a JSON file listing every unique deprecation warning found during the run. Review it to understand the scope of deprecations you need to address.
+
+## Step 7: Fix Current-Side Deprecations Unconditionally (Tier 1)
+
+Rails uses a deprecate-then-remove policy: the replacement API ships one version before the old form is removed. That means the new call almost always works on both the current and next sides, and the correct fix is Tier 1, an unconditional migration. **Do not wrap deprecation fixes in `NextRails.next?`**; that produces a dead branch you will only have to clean up later.
+
+Workflow:
+
+1. Pick a category of deprecation from the shitlist (for example, `update_attributes` → `update`).
+2. Replace every call site with the new API, on the current Rails version.
+3. Re-run `DEPRECATION_TRACKER=save bundle exec rspec`. The shitlist should shrink.
+4. Commit the fix.
+5. Repeat until the shitlist is empty or down to deprecations that genuinely cannot be resolved on current Rails.
+
+See `references/code-patterns.md` "Tier 1: Unconditional Migration" for the underlying rule and examples.
 
 ---
 
-## Step 4: Configure Gemfile with Version Conditionals
+# Phase 2: Dual-Boot
 
-The `next_rails` gem adds a `next?` helper method to your Gemfile. Use it to specify different versions of the dependency you are upgrading.
+Phase 2 is the Rails version hop. You now pin a different Rails version on the next side, install gems on that side, and fix genuine two-sided breakage that cannot be resolved by Tier 1.
+
+## Step 8: Configure the Gemfile with the Version Conditional
+
+`next_rails` adds a `next?` helper to your Gemfile. Use it to pin a different version of the dependency you are upgrading.
 
 **Do not dual-boot `config.load_defaults`.** It is post-upgrade work (rails-upgrade Step 10 / rails-load-defaults skill).
 
@@ -132,7 +221,7 @@ else
 end
 ```
 
-### Handling Related Gem Version Differences
+### Handling related gem version differences
 
 If other gems also need different versions to stay compatible:
 
@@ -148,9 +237,37 @@ end
 
 See `references/gemfile-examples.md` for more patterns.
 
----
+## Step 9: Identify and Pin Incompatible Gems
 
-## Step 5: Install Dependencies for Both Versions
+`BUNDLE_GEMFILE=Gemfile.next bundle install` often fails because the target Rails version pulls in incompatible majors of other gems (Rack, sprockets, and so on). Surface these conflicts **before** attempting the next-side install.
+
+1. **Run `bundle_report compatibility` up front.** `next_rails` ships a `bundle_report` CLI that flags which gems need version pinning for the target Rails:
+
+   ```bash
+   bundle_report compatibility --rails-version=<target_rails_version>
+   ```
+
+   Example: `bundle_report compatibility --rails-version=7.1`. The output lists gems whose current pins are incompatible with the target Rails, along with known-compatible versions.
+
+2. **If conflicts still arise during `BUNDLE_GEMFILE=Gemfile.next bundle install`**, read bundler's conflict output to identify the offending gem.
+
+3. **Look up a compatible version** via [RailsBump](https://railsbump.org/) or the gem's CHANGELOG.
+
+4. **Pin the next-compatible version inside the `if next?` block:**
+
+   ```ruby
+   if next?
+     gem 'rails', '~> 7.1.0'
+     gem 'some_gem', '~> 3.0'
+   else
+     gem 'rails', '~> 7.0.0'
+     gem 'some_gem', '~> 2.5'
+   end
+   ```
+
+5. **Re-run** `BUNDLE_GEMFILE=Gemfile.next bundle install` until it resolves cleanly.
+
+## Step 10: Install Dependencies for Both Versions
 
 ```bash
 # Install current version dependencies
@@ -165,9 +282,9 @@ cp Gemfile.lock Gemfile.next.lock
 BUNDLE_GEMFILE=Gemfile.next bundle install
 ```
 
----
+If `BUNDLE_GEMFILE=Gemfile.next bundle install` fails with a resolution error, loop back to Step 9.
 
-## Step 6: Verify Both Dependency Sets Work
+## Step 11: Verify Both Dependency Sets Boot and Run Tests
 
 Use the project's own test runner. Detect it first: `rspec-rails` in the Gemfile and a `spec/` directory → RSpec; `test/` and no `spec/` → Minitest; a `bin/test` wrapper → prefer it; `parallel_tests` / `turbo_tests` → use their binaries.
 
@@ -191,66 +308,32 @@ bin/rails test
 BUNDLE_GEMFILE=Gemfile.next bin/rails test
 ```
 
-If the project uses `rake test` instead of `bin/rails test`, or a parallel runner (`parallel_rspec`, `parallel_test`, `turbo_tests`), substitute that binary — the `BUNDLE_GEMFILE=Gemfile.next` prefix (or the `next` CLI) works with any of them.
+If the project uses `rake test` instead of `bin/rails test`, or a parallel runner (`parallel_rspec`, `parallel_test`, `turbo_tests`), substitute that binary. The `BUNDLE_GEMFILE=Gemfile.next` prefix (or the `next` CLI) works with any of them.
 
----
+## Step 12: Fix Two-Sided Breakage (Tier 2 / Tier 3)
 
-## Step 7: Set Up Deprecation Tracking with DeprecationTracker
+With current-side deprecations already resolved in Phase 1, anything still failing on the next side is genuine two-sided breakage: an API gone on the next side whose replacement does not backport to current, a behavior change between the two versions, or a gem-version gap where the gems pinned on each side expose different APIs.
 
-The `next_rails` gem includes `DeprecationTracker`, which captures all deprecation warnings during test runs and saves them to a JSON file. Set it up now so you have a complete deprecation inventory from the start.
+Use `references/code-patterns.md` "Three-Tier Approach" to decide how to handle each one:
 
-### Configure RSpec
+- **Tier 2**, a `NextRails.next?` conditional at the call site. Fits small gaps (up to about 20 call sites).
+- **Tier 3**, a backport or forwardport shim in a single file. Fits gaps that span an application layer (all controllers, all mailers) or 20+ call sites. Cleanup is a single-file delete.
 
-Add the following to `spec/spec_helper.rb` (or `spec/rails_helper.rb`):
+Do not fix deprecation warnings emitted by the **next** version here. Those belong to the preparatory phase of the _following_ upgrade (current-version deprecations for that hop), not this one's dual-boot work.
 
-```ruby
-RSpec.configure do |config|
-  DeprecationTracker.track_rspec(
-    config,
-    shitlist_path: "spec/support/deprecation_warning.shitlist.json",
-    mode: ENV.fetch("DEPRECATION_TRACKER", "save"),
-    transform_message: -> (message) { message.gsub("#{Rails.root}/", "") }
-  )
-end
-```
-
-### Generate the Initial Deprecation Inventory
-
-```bash
-DEPRECATION_TRACKER=save bundle exec rspec
-```
-
-This creates `spec/support/deprecation_warning.shitlist.json` — a JSON file listing every unique deprecation warning found during the run. Review it to understand the scope of deprecations you need to address.
-
-### Minitest
-
-For Minitest apps, use `DeprecationTracker.track_minitest` in `test/test_helper.rb`:
-
-```ruby
-DeprecationTracker.track_minitest(
-  shitlist_path: "test/support/deprecation_warning.shitlist.json",
-  mode: ENV.fetch("DEPRECATION_TRACKER", "save"),
-  transform_message: -> (message) { message.gsub("#{Rails.root}/", "") }
-)
-```
-
-Then generate the inventory with `DEPRECATION_TRACKER=save bin/rails test`. If `track_minitest` doesn't fit your setup (e.g., `minitest/parallel_fork`), fall back to the custom deprecation behavior approach in `references/deprecation-tracking.md` (Step 3).
-
-See `references/deprecation-tracking.md` for the full workflow (updating the shitlist, preventing regressions, CI with parallel execution, and alternative approaches).
-
----
-
-## Step 8: Commit Dual-Boot Setup
+## Step 13: Commit Dual-Boot Setup
 
 ```bash
 git add Gemfile Gemfile.next Gemfile.next.lock
 git commit -m "Add dual-boot setup for upgrade"
 ```
 
+Commit Tier 2 and Tier 3 fixes separately as you make them, ideally one per category.
+
 ---
 
 ## Next Steps
 
-- Configure CI to test both versions (see `references/ci-configuration.md`)
-- Start fixing breaking changes using `NextRails.next?` branching
-- See `references/code-patterns.md` for code examples
+- **CI is optional.** Local-only dual-boot is fully valid. Running both suites manually (`bundle exec rspec` and `BUNDLE_GEMFILE=Gemfile.next bundle exec rspec`) is a complete workflow. `references/ci-configuration.md` is a pointer for readers who want to automate, not a mandate.
+- Continue fixing breaking changes using the three-tier approach in `references/code-patterns.md`.
+- When the upgrade is complete, remove dual-boot scaffolding via `workflows/cleanup-workflow.md` (Tier 2: drop `else` branches; Tier 3: delete shim files; Gemfile: collapse the `if next?` block).


### PR DESCRIPTION
Closes #18.

Follow-up to #17. That PR closed #2 with a minimum-scope example swap (replaced the `fixture_path` / `serialize coder:` deprecation-only examples with a genuine two-sided breaking change). During review of #17, a larger structural problem surfaced: the skill's `SKILL.md` Pattern section and `references/code-patterns.md` jumped straight into app-code `NextRails.next?` branching as the default teaching, which overstates how often the reader should reach for it. Rails's deprecate-then-remove policy means the replacement API almost always backports to the current version, so unconditional migration is the correct fix for most adjacent-minor boundaries. This PR implements the reframe explicitly.

Separately: `next_rails` v1.5.0 (released 2026-04-02) shipped parallel-CI-native `DeprecationTracker` support. The previous `references/deprecation-tracking.md` documented a 25-line manual Ruby merge script that is now obsolete. This PR modernizes that file to use the v1.5.0 pattern (`node_index:` + `deprecations merge --delete-shards`).

## Summary of changes

### Gemfile-primacy reframe

- `CLAUDE.md` — added invariant #8: "prefer a single backport/forwardport shim over scattered conditionals when the version gap spans an application layer or affects roughly 20+ call sites".
- `dual-boot/SKILL.md` Pattern — first illustration is now the Gemfile `if next? ; gem 'rails', '~> 7.1.0' ; else ; gem 'rails', '~> 7.0.0' ; end` version pin (the canonical, always-required conditional). App-code branching is introduced as the exception. The `ignored_columns` example is retained as the Tier 2 illustration paired with a `respond_to?` WRONG counter-example.
- `dual-boot/references/code-patterns.md` — rewritten around the three-tier decision framework with cleanup semantics per tier.

### Three-tier decision framework

| Tier | Technique | When |
|------|-----------|------|
| 1 | Unconditional migration | Both Rails versions accept the new form (typical Rails deprecation case). |
| 2 | `NextRails.next?` conditional at the call site | New API doesn't exist on current (or old API raises on next). Smaller gaps (up to ~20 call sites). |
| 3 | Backport / forwardport shim | Same gap spans an application layer (all controllers, all mailers) or affects ~20+ call sites. |

- Tier 2 canonical example: `ignorable` gem's `ignore_columns` → native `ignored_columns=` at Rails 4.2 → 5.0 (from #17).
- Tier 3 canonical example: `ActionController::Parameters#values` backport at Rails 7.0 → 7.1, verified against rails/rails#44816. `params.values` changed from `Array<Hash>` to `Array<ActionController::Parameters>` in 7.1; a single initializer-level shim makes the 7.0 side return the 7.1 shape so all call sites stay identical across both versions.

### Cleanup covers all three tiers

`dual-boot/workflows/cleanup-workflow.md` — added a new Step 3 "Delete Backport / Forwardport Shim Files (Tier 3 cleanup)". Existing Step 2 covers per-call-site `else`-branch removal (Tier 2). Tier 1 needs nothing. Grep pattern provided for finding shim files; verification rubric distinguishes Tier-3 shim files (guard wraps a `module/class` redefinition) from Tier-2 call-site branches (guard wraps a single call or config).

### Two-phase setup workflow

`dual-boot/workflows/setup-workflow.md` — restructured from a single-phase setup into explicit Phase 1 (preparatory, no Rails version hop yet) and Phase 2 (dual-boot, the Rails version hop):

**Phase 1:**
1. Verify deprecation warnings not silenced (now a pointer to `references/deprecation-tracking.md`, removing duplication).
2. Check for existing `Gemfile.next`.
3. Add `next_rails` at Gemfile root.
4. Run `next_rails --init`.
5. Configure `DeprecationTracker`. Interactive branch: local/single-process gets the plain config; parallel CI gets the `node_index:` config and the `deprecations merge --delete-shards` fan-in step.
6. Capture deprecation inventory (`DEPRECATION_TRACKER=save`).
7. Fix current-side deprecations unconditionally (Tier 1 only, no `NextRails.next?` yet).

**Phase 2:**
8. Configure Gemfile with `if next?` version conditional.
9. Identify and pin incompatible gems using `bundle_report compatibility --rails-version=<target>` (a command provided by `next_rails`).
10. Install dependencies for both versions (lockfile-copy trick preserved).
11. Verify both sides boot and run tests.
12. Fix two-sided breakage using Tier 2 / Tier 3.
13. Commit.

### next_rails v1.5.0 modernization

`dual-boot/references/deprecation-tracking.md` — replaced the 25-line manual Ruby merge script with the v1.5.0 parallel-CI-native pattern:

```ruby
RSpec.configure do |config|
  if ENV["DEPRECATION_TRACKER"]
    DeprecationTracker.track_rspec(
      config,
      node_index: ENV["CI_NODE_INDEX"]
    )
  end
end
```

```bash
# Save phase (each parallel node)
DEPRECATION_TRACKER=save CI_NODE_INDEX=$NODE bundle exec rspec <subset>

# Merge phase (runs once after all nodes finish)
deprecations merge --delete-shards

# Compare phase (each parallel node)
DEPRECATION_TRACKER=compare CI_NODE_INDEX=$NODE bundle exec rspec <subset>
```

Platform-specific env var mapping included (CircleCI → `CIRCLE_NODE_INDEX`, Buildkite → `BUILDKITE_PARALLEL_JOB`, GitLab → `CI_NODE_INDEX`, Semaphore → `SEMAPHORE_JOB_INDEX`). Minimum version requirement (`next_rails >= 1.5.0`) documented in both `setup-workflow.md` and `references/deprecation-tracking.md`.

Also added a last-resort grep fallback at the bottom of `deprecation-tracking.md` for apps where `DeprecationTracker` cannot be configured (loses structure, compare mode, and regression gating — use the tracker when possible).

### Workflow separation in the basic-setup walkthrough

`dual-boot/examples/basic-setup.md` — added a "Before You Start: Resolve Current-Version Deprecations" section that frames current-version deprecation resolution as a Tier 1 prerequisite, not a step inside dual-boot fixing. Step 6 rescoped to genuine two-sided breakage only. Explicit: do not fix next-version deprecations here — those belong to the preparatory phase of the next upgrade.

### Other

- CI setup is now explicitly documented as optional — local-only dual-boot is equally valid via manual two-suite invocation.
- All pointers to deprecation-resolution workflow cite dual-boot's own `references/deprecation-tracking.md`, keeping this PR self-contained and forward-compatible whether or not rails-upgrade PR #31 lands.

## Parent branch

Branched off `feature/issue-2-better-examples` (PR #17). Merge order: #17 first, then rebase this branch onto `main` if needed.

## Out of scope (deferred or rejected)

- Multi-hop upgrades — stays out. Follows the FastRuby.io methodology: one adjacent-minor at a time.
- Deprecation-tracking as separate skill scope — flagged for later consideration; not a blocker.
- README.md Key Principle expansion — stays at the `ignored_columns` conditional from #17.
- v1.4.x fallback for `next_rails` — require v1.5.0+; older users should upgrade.

