### PR TITLE
Sweep .rspec for deprecation behavior in Step 0

### DIFF
--- a/dual-boot/references/deprecation-tracking.md
+++ b/dual-boot/references/deprecation-tracking.md
@@ -40,6 +40,24 @@ ActiveSupport::Deprecation.silenced = true
 ActiveSupport::Deprecation.silence { ... }
 ```
 
+### Check `.rspec` and other autoloaded test config
+
+Deprecation behavior can also be installed by RSpec autoloads, not just `config/`. A single line in `.rspec` like
+
+```
+# .rspec
+-r raise_errors_for_deprecations
+```
+
+installs an RSpec hook that raises on every `ActiveSupport::Deprecation.warn`. That is sometimes intentional (strict mode for clean projects), but it changes how every test failure should be interpreted — and it's easy to miss because nothing about it lives under `config/`. The same applies to hooks installed via `RSpec.configure { |c| c.raise_errors_for_deprecations! }` in `spec_helper.rb`, `rails_helper.rb`, or `spec/support/`.
+
+Sweep these locations:
+
+- `.rspec`, `spec/.rspec`
+- `spec/spec_helper.rb`, `spec/rails_helper.rb`, `spec/support/**/*.rb`
+- `Rakefile`, `lib/tasks/*.rake`
+- Any Bundler-loaded test-group gem that wires deprecation behavior
+
 ### Detection Commands
 
 Search from the project root to catch configuration in any directory structure (standard Rails, Packwerk packs, engines, etc.):
@@ -49,10 +67,23 @@ Search from the project root to catch configuration in any directory structure (
 grep -rn "active_support.deprecation" .
 grep -rn "report_deprecations" .
 grep -rn "Deprecation.silenced" .
-grep -rn "Deprecation.silence" .
+grep -rnE "ActiveSupport::Deprecation\.silence\b" .
+grep -rn "raise_errors_for_deprecations" .
 ```
 
-If any of these are silencing deprecations, fix them before proceeding with the upgrade.
+The last one catches both the `.rspec` autoload (`-r raise_errors_for_deprecations`) and the in-helper hook (`config.raise_errors_for_deprecations!`).
+
+For a single sweep:
+
+```bash
+grep -rnE "raise_errors_for_deprecations|ActiveSupport::Deprecation\.(behavior|disallowed_behavior|silenced)\s*=|ActiveSupport::Deprecation\.silence\b|deprecation.*silence|report_deprecations.*false" \
+  .rspec spec/.rspec spec/spec_helper.rb spec/rails_helper.rb Rakefile \
+  config/ spec/support/ lib/tasks/ 2>/dev/null
+```
+
+The `silence\b` alternation catches the block form `ActiveSupport::Deprecation.silence do ... end`. The `\b` word boundary keeps it from matching `silenced` (already covered by the assignment branch).
+
+If any of these are silencing deprecations, fix them before proceeding with the upgrade. If `raise_errors_for_deprecations` is in place, decide whether to keep it (strict mode) or temporarily relax it during triage so test failures don't conflate "deprecation warning fired" with "real assertion failure".
 
 ---
 
@@ -274,6 +305,8 @@ After completing the upgrade:
 | What to check | Command |
 |---|---|
 | Silenced deprecations | `grep -rn "deprecation.*silence\|silenced.*true\|report_deprecations.*false" .` |
+| Block-form silencing | `grep -rnE "ActiveSupport::Deprecation\.silence\b" .` |
+| Autoloaded raise hooks | `grep -rn "raise_errors_for_deprecations" .` |
 | Current behavior | `grep -rn "active_support.deprecation" .` |
 | Custom behaviors | `grep -rn "Deprecation.behavior" .` |
 | Save deprecation inventory | `DEPRECATION_TRACKER=save bundle exec rspec` |

--- a/dual-boot/workflows/setup-workflow.md
+++ b/dual-boot/workflows/setup-workflow.md
@@ -13,15 +13,28 @@ Before setting up dual-boot, ensure deprecation warnings are visible. Silenced d
 
 **Check for silenced deprecations:**
 
+`config/` is not the only place this gets configured. RSpec autoloads `-r` requires from `.rspec`, and test helpers can install hooks like `RSpec.configure { |c| c.raise_errors_for_deprecations! }`. Sweep these locations as well:
+
+- `.rspec`, `spec/.rspec` (look for `-r raise_errors_for_deprecations` and similar autoloads)
+- `spec/spec_helper.rb`, `spec/rails_helper.rb`, `spec/support/**/*.rb`
+- `Rakefile`, `lib/tasks/*.rake`
+- Any Bundler-loaded test-group gem that wires deprecation behavior
+
 ```bash
-grep -rn "deprecation.*silence\|silenced.*true\|report_deprecations.*false" config/
+grep -rnE "raise_errors_for_deprecations|ActiveSupport::Deprecation\.(behavior|disallowed_behavior|silenced)\s*=|ActiveSupport::Deprecation\.silence\b|deprecation.*silence|silenced.*true|report_deprecations.*false" \
+  .rspec spec/.rspec spec/spec_helper.rb spec/rails_helper.rb Rakefile \
+  config/ spec/support/ lib/tasks/ 2>/dev/null
 ```
+
+The `silence\b` alternation catches the block form `ActiveSupport::Deprecation.silence do ... end`. The `\b` word boundary keeps it from matching `silenced` (already covered by the assignment branch).
 
 **If deprecations are silenced:**
 1. Change `:silence` to `:stderr` or `:log` (or `:raise` if you want strict mode)
 2. Remove `ActiveSupport::Deprecation.silenced = true` if found
 3. Remove `config.active_support.report_deprecations = false` if found (Rails 7.0+)
-4. Run the test suite to see current deprecation warnings
+4. Review any `Deprecation.silence do ... end` blocks. Each one hides a deprecation that should be triaged rather than suppressed.
+5. Review any `raise_errors_for_deprecations` autoload. Useful in strict mode, but worth knowing it's installed before interpreting test failures.
+6. Run the test suite to see current deprecation warnings
 
 See `references/deprecation-tracking.md` for detailed configuration guidance, including a gradual approach using custom deprecation behaviors for apps with many existing warnings.
 


### PR DESCRIPTION
Related to ombulabs/claude-code_rails-upgrade-skill#100 (same gap, different repo).

## Summary

- Extend Step 0 (`Verify Deprecation Warnings Are Not Silenced`) in `dual-boot/workflows/setup-workflow.md` to sweep `.rspec`, `spec/.rspec`, `spec/spec_helper.rb`, `spec/rails_helper.rb`, `spec/support/`, `Rakefile`, and `lib/tasks/`. The current grep targets `config/` only, which misses RSpec autoloads and helper hooks.
- Mirror the same guidance in `dual-boot/references/deprecation-tracking.md` under "Detect If Deprecations Are Silenced", with a `.rspec` autoload example and the block-form silencing pattern (`Deprecation.silence do ... end`).
- Extend the regex with `ActiveSupport::Deprecation\.silence\b` for block-form silencing. The `\b` word boundary keeps it from matching `silenced` (already covered by the assignment branch).
- Add follow-up steps for triaging block-form silencing and `raise_errors_for_deprecations` autoloads when found.

## Why this matters

The silence check is meant to answer "what is the project's deprecation behavior right now?" before starting an upgrade. RSpec autoloads `-r raise_errors_for_deprecations` from `.rspec`, and helper hooks like `RSpec.configure { |c| c.raise_errors_for_deprecations! }` install raise behavior. A single line in `.rspec` can change how every test failure is interpreted — and nothing about it lives under `config/`. Without these locations in the sweep, "no deprecation warnings in the log" can mean "they are being silenced", and "every test fails after the upgrade" can mean "they have been raising for a long time, unrelated to the upgrade".

## Test plan

- [x] Docs-only change. Verified while exercising the skill on a legacy Rails app where `.rspec` autoloaded `raise_errors_for_deprecations` and the original Step 0 grep would have missed it.
- [x] The combined regex was exercised against the same codebase and surfaces `.rspec` autoloads, the `raise_errors_for_deprecations!` helper hook, and any `Deprecation.silence do` blocks alongside the existing assignment-form patterns.
- [x] The Quick Reference table picked up two new rows (block-form silencing, autoloaded raise hooks).

## Note

The original gap was reported against `OmbuLabs/claude-code_rails-upgrade-skill` (issue #100, PR #101). This PR carries the same fix into the dual-boot skill where the parallel guidance lives. Linking instead of opening a duplicate issue.
